### PR TITLE
Sort invoice transactions from oldest to newest

### DIFF
--- a/invoices_service.go
+++ b/invoices_service.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/xml"
 	"fmt"
+	"sort"
 )
 
 var _ InvoicesService = &invoicesImpl{}
@@ -55,7 +56,8 @@ func (s *invoicesImpl) ListAccount(accountCode string, params Params) (*Response
 }
 
 // Get returns detailed information about an invoice including line items and
-// payments.
+// payments. Transactions returned with the invoice are sorted from oldest to
+// newest.
 // https://dev.recurly.com/docs/lookup-invoice-details
 func (s *invoicesImpl) Get(invoiceNumber int) (*Response, *Invoice, error) {
 	action := fmt.Sprintf("invoices/%d", invoiceNumber)
@@ -66,6 +68,9 @@ func (s *invoicesImpl) Get(invoiceNumber int) (*Response, *Invoice, error) {
 
 	var dst Invoice
 	resp, err := s.client.do(req, &dst)
+
+	// Sort transactions.
+	sort.Sort(Transactions(dst.Transactions))
 
 	return resp, &dst, err
 }

--- a/transactions.go
+++ b/transactions.go
@@ -184,3 +184,19 @@ func (c CVVResult) UnableToProcess() bool {
 type AVSResult struct {
 	TransactionResult
 }
+
+// Transactions is a sortable slice of Transaction.
+// It implements sort.Interface.
+type Transactions []Transaction
+
+func (s Transactions) Len() int {
+	return len(s)
+}
+
+func (s Transactions) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s Transactions) Less(i, j int) bool {
+	return s[i].CreatedAt.Time.Before(*s[j].CreatedAt.Time)
+}


### PR DESCRIPTION
Calling `Invoices.Get` returns a slice of `Transaction`. It appears they are sorted from oldest to newest coming out of the recurly API, but it's not documented. This PR adds sorting so that the order is guaranteed.