### PR TITLE
Add PendingSubscription to subscription struct for renewal updates

### DIFF
--- a/subscriptions.go
+++ b/subscriptions.go
@@ -32,60 +32,60 @@ const (
 
 // Subscription represents an individual subscription.
 type Subscription struct {
-	XMLName                xml.Name            `xml:"subscription"`
-	Plan                   NestedPlan          `xml:"plan,omitempty"`
-	AccountCode            string              `xml:"-"`
-	InvoiceNumber          int                 `xml:"-"`
-	UUID                   string              `xml:"uuid,omitempty"`
-	State                  string              `xml:"state,omitempty"`
-	UnitAmountInCents      int                 `xml:"unit_amount_in_cents,omitempty"`
-	Currency               string              `xml:"currency,omitempty"`
-	Quantity               int                 `xml:"quantity,omitempty"`
-	ActivatedAt            NullTime            `xml:"activated_at,omitempty"`
-	CanceledAt             NullTime            `xml:"canceled_at,omitempty"`
-	ExpiresAt              NullTime            `xml:"expires_at,omitempty"`
-	CurrentPeriodStartedAt NullTime            `xml:"current_period_started_at,omitempty"`
-	CurrentPeriodEndsAt    NullTime            `xml:"current_period_ends_at,omitempty"`
-	TrialStartedAt         NullTime            `xml:"trial_started_at,omitempty"`
-	TrialEndsAt            NullTime            `xml:"trial_ends_at,omitempty"`
-	TaxInCents             int                 `xml:"tax_in_cents,omitempty"`
-	TaxType                string              `xml:"tax_type,omitempty"`
-	TaxRegion              string              `xml:"tax_region,omitempty"`
-	TaxRate                float64             `xml:"tax_rate,omitempty"`
-	PONumber               string              `xml:"po_number,omitempty"`
-	NetTerms               NullInt             `xml:"net_terms,omitempty"`
-	SubscriptionAddOns     []SubscriptionAddOn `xml:"subscription_add_ons>subscription_add_on,omitempty"`
-	PendingSubscription    PendingSubscription `xml:"pending_subscription,omitempty"`
+	XMLName                xml.Name             `xml:"subscription"`
+	Plan                   NestedPlan           `xml:"plan,omitempty"`
+	AccountCode            string               `xml:"-"`
+	InvoiceNumber          int                  `xml:"-"`
+	UUID                   string               `xml:"uuid,omitempty"`
+	State                  string               `xml:"state,omitempty"`
+	UnitAmountInCents      int                  `xml:"unit_amount_in_cents,omitempty"`
+	Currency               string               `xml:"currency,omitempty"`
+	Quantity               int                  `xml:"quantity,omitempty"`
+	ActivatedAt            NullTime             `xml:"activated_at,omitempty"`
+	CanceledAt             NullTime             `xml:"canceled_at,omitempty"`
+	ExpiresAt              NullTime             `xml:"expires_at,omitempty"`
+	CurrentPeriodStartedAt NullTime             `xml:"current_period_started_at,omitempty"`
+	CurrentPeriodEndsAt    NullTime             `xml:"current_period_ends_at,omitempty"`
+	TrialStartedAt         NullTime             `xml:"trial_started_at,omitempty"`
+	TrialEndsAt            NullTime             `xml:"trial_ends_at,omitempty"`
+	TaxInCents             int                  `xml:"tax_in_cents,omitempty"`
+	TaxType                string               `xml:"tax_type,omitempty"`
+	TaxRegion              string               `xml:"tax_region,omitempty"`
+	TaxRate                float64              `xml:"tax_rate,omitempty"`
+	PONumber               string               `xml:"po_number,omitempty"`
+	NetTerms               NullInt              `xml:"net_terms,omitempty"`
+	SubscriptionAddOns     []SubscriptionAddOn  `xml:"subscription_add_ons>subscription_add_on,omitempty"`
+	PendingSubscription    *PendingSubscription `xml:"pending_subscription,omitempty"`
 }
 
 // UnmarshalXML unmarshals transactions and handles intermediary state during unmarshaling
 // for types like href.
 func (s *Subscription) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	var v struct {
-		XMLName                xml.Name            `xml:"subscription"`
-		Plan                   NestedPlan          `xml:"plan,omitempty"`
-		AccountCode            hrefString          `xml:"account"`
-		InvoiceNumber          hrefInt             `xml:"invoice"`
-		UUID                   string              `xml:"uuid,omitempty"`
-		State                  string              `xml:"state,omitempty"`
-		UnitAmountInCents      int                 `xml:"unit_amount_in_cents,omitempty"`
-		Currency               string              `xml:"currency,omitempty"`
-		Quantity               int                 `xml:"quantity,omitempty"`
-		ActivatedAt            NullTime            `xml:"activated_at,omitempty"`
-		CanceledAt             NullTime            `xml:"canceled_at,omitempty"`
-		ExpiresAt              NullTime            `xml:"expires_at,omitempty"`
-		CurrentPeriodStartedAt NullTime            `xml:"current_period_started_at,omitempty"`
-		CurrentPeriodEndsAt    NullTime            `xml:"current_period_ends_at,omitempty"`
-		TrialStartedAt         NullTime            `xml:"trial_started_at,omitempty"`
-		TrialEndsAt            NullTime            `xml:"trial_ends_at,omitempty"`
-		TaxInCents             int                 `xml:"tax_in_cents,omitempty"`
-		TaxType                string              `xml:"tax_type,omitempty"`
-		TaxRegion              string              `xml:"tax_region,omitempty"`
-		TaxRate                float64             `xml:"tax_rate,omitempty"`
-		PONumber               string              `xml:"po_number,omitempty"`
-		NetTerms               NullInt             `xml:"net_terms,omitempty"`
-		SubscriptionAddOns     []SubscriptionAddOn `xml:"subscription_add_ons>subscription_add_on,omitempty"`
-		PendingSubscription    PendingSubscription `xml:"pending_subscription,omitempty"`
+		XMLName                xml.Name             `xml:"subscription"`
+		Plan                   NestedPlan           `xml:"plan,omitempty"`
+		AccountCode            hrefString           `xml:"account"`
+		InvoiceNumber          hrefInt              `xml:"invoice"`
+		UUID                   string               `xml:"uuid,omitempty"`
+		State                  string               `xml:"state,omitempty"`
+		UnitAmountInCents      int                  `xml:"unit_amount_in_cents,omitempty"`
+		Currency               string               `xml:"currency,omitempty"`
+		Quantity               int                  `xml:"quantity,omitempty"`
+		ActivatedAt            NullTime             `xml:"activated_at,omitempty"`
+		CanceledAt             NullTime             `xml:"canceled_at,omitempty"`
+		ExpiresAt              NullTime             `xml:"expires_at,omitempty"`
+		CurrentPeriodStartedAt NullTime             `xml:"current_period_started_at,omitempty"`
+		CurrentPeriodEndsAt    NullTime             `xml:"current_period_ends_at,omitempty"`
+		TrialStartedAt         NullTime             `xml:"trial_started_at,omitempty"`
+		TrialEndsAt            NullTime             `xml:"trial_ends_at,omitempty"`
+		TaxInCents             int                  `xml:"tax_in_cents,omitempty"`
+		TaxType                string               `xml:"tax_type,omitempty"`
+		TaxRegion              string               `xml:"tax_region,omitempty"`
+		TaxRate                float64              `xml:"tax_rate,omitempty"`
+		PONumber               string               `xml:"po_number,omitempty"`
+		NetTerms               NullInt              `xml:"net_terms,omitempty"`
+		SubscriptionAddOns     []SubscriptionAddOn  `xml:"subscription_add_ons>subscription_add_on,omitempty"`
+		PendingSubscription    *PendingSubscription `xml:"pending_subscription,omitempty"`
 	}
 	if err := d.DecodeElement(&v, &start); err != nil {
 		return err

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -55,6 +55,7 @@ type Subscription struct {
 	PONumber               string              `xml:"po_number,omitempty"`
 	NetTerms               NullInt             `xml:"net_terms,omitempty"`
 	SubscriptionAddOns     []SubscriptionAddOn `xml:"subscription_add_ons>subscription_add_on,omitempty"`
+	PendingSubscription    PendingSubscription `xml:"pending_subscription,omitempty"`
 }
 
 // UnmarshalXML unmarshals transactions and handles intermediary state during unmarshaling
@@ -84,6 +85,7 @@ func (s *Subscription) UnmarshalXML(d *xml.Decoder, start xml.StartElement) erro
 		PONumber               string              `xml:"po_number,omitempty"`
 		NetTerms               NullInt             `xml:"net_terms,omitempty"`
 		SubscriptionAddOns     []SubscriptionAddOn `xml:"subscription_add_ons>subscription_add_on,omitempty"`
+		PendingSubscription    PendingSubscription `xml:"pending_subscription,omitempty"`
 	}
 	if err := d.DecodeElement(&v, &start); err != nil {
 		return err
@@ -112,6 +114,7 @@ func (s *Subscription) UnmarshalXML(d *xml.Decoder, start xml.StartElement) erro
 		PONumber:               v.PONumber,
 		NetTerms:               v.NetTerms,
 		SubscriptionAddOns:     v.SubscriptionAddOns,
+		PendingSubscription:    v.PendingSubscription,
 	}
 
 	return nil
@@ -143,6 +146,15 @@ type SubscriptionAddOn struct {
 	Code              string   `xml:"add_on_code"`
 	UnitAmountInCents int      `xml:"unit_amount_in_cents"`
 	Quantity          int      `xml:"quantity,omitempty"`
+}
+
+// PendingSubscription are updates to the subscription or subscription add ons that
+// will be made on the next renewal.
+type PendingSubscription struct {
+	XMLName            xml.Name            `xml:"pending_subscription"`
+	Plan               NestedPlan          `xml:"plan,omitempty"`
+	Quantity           int                 `xml:"quantity,omitempty"` // Quantity of subscriptions
+	SubscriptionAddOns []SubscriptionAddOn `xml:"subscription_add_ons>subscription_add_on,omitempty"`
 }
 
 // NewSubscription is used to create new subscriptions.

--- a/subscriptions_test.go
+++ b/subscriptions_test.go
@@ -682,7 +682,7 @@ func TestSubscriptions_Get_PendingSubscription(t *testing.T) {
 		TaxRegion:              "CA",
 		TaxRate:                0.0875,
 		NetTerms:               recurly.NewInt(0),
-		PendingSubscription: recurly.PendingSubscription{
+		PendingSubscription: &recurly.PendingSubscription{
 			XMLName: xml.Name{Local: "pending_subscription"},
 			Plan: recurly.NestedPlan{
 				Code: "gold",

--- a/subscriptions_test.go
+++ b/subscriptions_test.go
@@ -589,6 +589,128 @@ func TestSubscriptions_Get(t *testing.T) {
 	}
 }
 
+func TestSubscriptions_Get_PendingSubscription(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/subscriptions/44f83d7cba354d5b84812419f923ea96", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		w.WriteHeader(200)
+		fmt.Fprint(w, `<?xml version="1.0" encoding="UTF-8"?>
+		<subscription href="https://your-subdomain.recurly.com/v2/subscriptions/44f83d7cba354d5b84812419f923ea96">
+			<account href="https://your-subdomain.recurly.com/v2/accounts/1"/>
+			<invoice href="https://your-subdomain.recurly.com/v2/invoices/1108"/>
+			<plan href="https://your-subdomain.recurly.com/v2/plans/gold">
+			  <plan_code>gold</plan_code>
+			  <name>Gold plan</name>
+			</plan>
+			<uuid>44f83d7cba354d5b84812419f923ea96</uuid>
+			<state>active</state>
+			<unit_amount_in_cents type="integer">800</unit_amount_in_cents>
+			<currency>EUR</currency>
+			<quantity type="integer">1</quantity>
+			<activated_at type="datetime">2011-05-27T07:00:00Z</activated_at>
+			<canceled_at nil="nil"></canceled_at>
+			<expires_at nil="nil"></expires_at>
+			<current_period_started_at type="datetime">2011-06-27T07:00:00Z</current_period_started_at>
+			<current_period_ends_at type="datetime">2011-07-27T07:00:00Z</current_period_ends_at>
+			<trial_started_at nil="nil"></trial_started_at>
+			<trial_ends_at nil="nil"></trial_ends_at>
+			<tax_in_cents type="integer">72</tax_in_cents>
+			<tax_type>usst</tax_type>
+			<tax_region>CA</tax_region>
+			<tax_rate type="float">0.0875</tax_rate>
+			<po_number nil="nil"></po_number>
+			<net_terms type="integer">0</net_terms>
+			<subscription_add_ons type="array">
+			</subscription_add_ons>
+			<pending_subscription type="subscription">
+				<plan href="https://blacklighttest.recurly.com/v2/plans/integrationtestcode">
+					<plan_code>gold</plan_code>
+					<name>Gold plan</name>
+				</plan>
+				<unit_amount_in_cents type="integer">50000</unit_amount_in_cents>
+				<quantity type="integer">1</quantity>
+				<subscription_add_ons type="array">
+					<subscription_add_on>
+						<add_on_type>fixed</add_on_type>
+						<add_on_code>add-on-one</add_on_code>
+						<unit_amount_in_cents type="integer">1100</unit_amount_in_cents>
+						<quantity type="integer">1</quantity>
+					</subscription_add_on>
+					<subscription_add_on>
+						<add_on_type>fixed</add_on_type>
+						<add_on_code>add-on-two</add_on_code>
+						<unit_amount_in_cents type="integer">1300</unit_amount_in_cents>
+						<quantity type="integer">1</quantity>
+					</subscription_add_on>
+				</subscription_add_ons>
+			</pending_subscription>
+			<a name="cancel" href="https://your-subdomain.recurly.com/v2/subscriptions/44f83d7cba354d5b84812419f923ea96/cancel" method="put"/>
+			<a name="terminate" href="https://your-subdomain.recurly.com/v2/subscriptions/44f83d7cba354d5b84812419f923ea96/terminate" method="put"/>
+			<a name="postpone" href="https://your-subdomain.recurly.com/v2/subscriptions/44f83d7cba354d5b84812419f923ea96/postpone" method="put"/>
+		</subscription>`)
+	})
+
+	r, subscription, err := client.Subscriptions.Get("44f83d7cba354d5b84812419f923ea96")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	} else if r.IsError() {
+		t.Fatal("expected list subcriptions to return OK")
+	}
+
+	if !reflect.DeepEqual(subscription, &recurly.Subscription{
+		XMLName: xml.Name{Local: "subscription"},
+		Plan: recurly.NestedPlan{
+			Code: "gold",
+			Name: "Gold plan",
+		},
+		AccountCode:            "1",
+		InvoiceNumber:          1108,
+		UUID:                   "44f83d7cba354d5b84812419f923ea96",
+		State:                  "active",
+		UnitAmountInCents:      800,
+		Currency:               "EUR",
+		Quantity:               1,
+		ActivatedAt:            recurly.NewTime(time.Date(2011, time.May, 27, 7, 0, 0, 0, time.UTC)),
+		CurrentPeriodStartedAt: recurly.NewTime(time.Date(2011, time.June, 27, 7, 0, 0, 0, time.UTC)),
+		CurrentPeriodEndsAt:    recurly.NewTime(time.Date(2011, time.July, 27, 7, 0, 0, 0, time.UTC)),
+		TaxInCents:             72,
+		TaxType:                "usst",
+		TaxRegion:              "CA",
+		TaxRate:                0.0875,
+		NetTerms:               recurly.NewInt(0),
+		PendingSubscription: recurly.PendingSubscription{
+			XMLName: xml.Name{Local: "pending_subscription"},
+			Plan: recurly.NestedPlan{
+				Code: "gold",
+				Name: "Gold plan",
+			},
+			Quantity: 1,
+			SubscriptionAddOns: []recurly.SubscriptionAddOn{
+				{
+					XMLName:           xml.Name{Local: "subscription_add_on"},
+					Type:              "fixed",
+					Code:              "add-on-one",
+					UnitAmountInCents: 1100,
+					Quantity:          1,
+				},
+				{
+					XMLName:           xml.Name{Local: "subscription_add_on"},
+					Type:              "fixed",
+					Code:              "add-on-two",
+					UnitAmountInCents: 1300,
+					Quantity:          1,
+				},
+			},
+		},
+	}) {
+		t.Fatalf("unexpected subscription: %#v", subscription)
+	}
+}
+
 func TestSubscriptions_Create(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
When a "renewal" update has been made to a subscription (`<timeframe>renewal</timeframe>`) the changes appear in a `pending_subscription` tag in xml returned by Recurly. This PR adds a `PendingSubscription` struct to the unmarshal function and adds a test. 

https://docs.recurly.com/docs/subscriptions#section-at-renewal-changes