### PR TITLE
Return nil structs on Get calls for 400+ status codes

### DIFF
--- a/accounts_service.go
+++ b/accounts_service.go
@@ -3,6 +3,7 @@ package recurly
 import (
 	"encoding/xml"
 	"fmt"
+	"net/http"
 )
 
 const (
@@ -58,6 +59,10 @@ func (s *accountsImpl) Get(code string) (*Response, *Account, error) {
 
 	var a Account
 	resp, err := s.client.do(req, &a)
+	if err != nil || resp.StatusCode >= http.StatusBadRequest {
+		return resp, nil, err
+	}
+
 	a.BillingInfo = nil
 
 	return resp, &a, err

--- a/accounts_test.go
+++ b/accounts_test.go
@@ -231,6 +231,26 @@ func TestAccounts_Get(t *testing.T) {
 	}
 }
 
+func TestAccounts_Get_ErrNotFound(t *testing.T) {
+	setup()
+	defer teardown()
+
+	var invoked bool
+	mux.HandleFunc("/v2/accounts/1", func(w http.ResponseWriter, r *http.Request) {
+		invoked = true
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	_, account, err := client.Accounts.Get("1")
+	if !invoked {
+		t.Fatal("handler not invoked")
+	} else if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	} else if account != nil {
+		t.Fatalf("expected account to be nil: %#v", account)
+	}
+}
+
 func TestAccounts_LookupAccountBalance(t *testing.T) {
 	setup()
 	defer teardown()

--- a/add_ons_service.go
+++ b/add_ons_service.go
@@ -3,6 +3,7 @@ package recurly
 import (
 	"encoding/xml"
 	"fmt"
+	"net/http"
 )
 
 var _ AddOnsService = &addOnsImpl{}
@@ -47,6 +48,9 @@ func (s *addOnsImpl) Get(planCode string, code string) (*Response, *AddOn, error
 
 	var dst AddOn
 	resp, err := s.client.do(req, &dst)
+	if err != nil || resp.StatusCode >= http.StatusBadRequest {
+		return resp, nil, err
+	}
 
 	return resp, &dst, err
 }

--- a/add_ons_test.go
+++ b/add_ons_test.go
@@ -146,6 +146,26 @@ func TestAddOns_Get(t *testing.T) {
 	}
 }
 
+func TestAddOns_Get_ErrNotFound(t *testing.T) {
+	setup()
+	defer teardown()
+
+	var invoked bool
+	mux.HandleFunc("/v2/plans/gold/add_ons/ipaddresses", func(w http.ResponseWriter, r *http.Request) {
+		invoked = true
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	_, addons, err := client.AddOns.Get("gold", "ipaddresses")
+	if !invoked {
+		t.Fatal("handler not invoked")
+	} else if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	} else if addons != nil {
+		t.Fatalf("expected addons to be nil: %#v", addons)
+	}
+}
+
 func TestAddOns_Create(t *testing.T) {
 	setup()
 	defer teardown()

--- a/adjustments_service.go
+++ b/adjustments_service.go
@@ -3,6 +3,7 @@ package recurly
 import (
 	"encoding/xml"
 	"fmt"
+	"net/http"
 )
 
 var _ AdjustmentsService = &adjustmentsImpl{}
@@ -47,6 +48,9 @@ func (s *adjustmentsImpl) Get(uuid string) (*Response, *Adjustment, error) {
 
 	var dst Adjustment
 	resp, err := s.client.do(req, &dst)
+	if err != nil || resp.StatusCode >= http.StatusBadRequest {
+		return resp, nil, err
+	}
 
 	return resp, &dst, err
 }

--- a/adjustments_test.go
+++ b/adjustments_test.go
@@ -243,6 +243,26 @@ func TestAdjustments_Get(t *testing.T) {
 	}
 }
 
+func TestAdjustments_Get_ErrNotFound(t *testing.T) {
+	setup()
+	defer teardown()
+
+	var invoked bool
+	mux.HandleFunc("/v2/adjustments/626db120a84102b1809909071c701c60", func(w http.ResponseWriter, r *http.Request) {
+		invoked = true
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	_, adjustment, err := client.Adjustments.Get("626db120a84102b1809909071c701c60")
+	if !invoked {
+		t.Fatal("handler not invoked")
+	} else if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	} else if adjustment != nil {
+		t.Fatalf("expected adjustment to be nil: %#v", adjustment)
+	}
+}
+
 func TestAdjustments_Create(t *testing.T) {
 	setup()
 	defer teardown()

--- a/billing_service.go
+++ b/billing_service.go
@@ -1,6 +1,9 @@
 package recurly
 
-import "fmt"
+import (
+	"fmt"
+	"net/http"
+)
 
 var _ BillingService = &billingImpl{}
 
@@ -26,6 +29,9 @@ func (s *billingImpl) Get(accountCode string) (*Response, *Billing, error) {
 
 	var dst Billing
 	resp, err := s.client.do(req, &dst)
+	if err != nil || resp.StatusCode >= http.StatusBadRequest {
+		return resp, nil, err
+	}
 
 	return resp, &dst, err
 }

--- a/billing_test.go
+++ b/billing_test.go
@@ -132,6 +132,26 @@ func TestBilling_Get(t *testing.T) {
 	}
 }
 
+func TestBilling_Get_ErrNotFound(t *testing.T) {
+	setup()
+	defer teardown()
+
+	var invoked bool
+	mux.HandleFunc("/v2/accounts/1/billing_info", func(w http.ResponseWriter, r *http.Request) {
+		invoked = true
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	_, billing, err := client.Billing.Get("1")
+	if !invoked {
+		t.Fatal("handler not invoked")
+	} else if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	} else if billing != nil {
+		t.Fatalf("expected billing to be nil: %#v", billing)
+	}
+}
+
 func TestBilling_Create_WithToken(t *testing.T) {
 	setup()
 	defer teardown()

--- a/client.go
+++ b/client.go
@@ -119,7 +119,7 @@ func (c *Client) do(req *http.Request, v interface{}) (*Response, error) {
 	response := &Response{Response: resp}
 	decoder := xml.NewDecoder(resp.Body)
 	if response.IsError() { // Parse validation errors
-		if response.StatusCode == 422 {
+		if response.StatusCode == http.StatusUnprocessableEntity {
 			var ve struct {
 				XMLName          xml.Name          `xml:"errors"`
 				Errors           []Error           `xml:"error"`
@@ -140,7 +140,9 @@ func (c *Client) do(req *http.Request, v interface{}) (*Response, error) {
 				Symbol      string   `xml:"symbol"`
 				Description string   `xml:"description"`
 			}
-			if err = decoder.Decode(&ve); err != nil {
+			if err = decoder.Decode(&ve); err == io.EOF {
+				return response, nil
+			} else if err != nil {
 				return response, err
 			}
 

--- a/coupons_service.go
+++ b/coupons_service.go
@@ -3,6 +3,7 @@ package recurly
 import (
 	"encoding/xml"
 	"fmt"
+	"net/http"
 )
 
 var _ CouponsService = &couponsImpl{}
@@ -46,6 +47,9 @@ func (s *couponsImpl) Get(code string) (*Response, *Coupon, error) {
 
 	var dst Coupon
 	resp, err := s.client.do(req, &dst)
+	if err != nil || resp.StatusCode >= http.StatusBadRequest {
+		return resp, nil, err
+	}
 
 	return resp, &dst, err
 }

--- a/coupons_test.go
+++ b/coupons_test.go
@@ -269,6 +269,26 @@ func TestCoupons_Get(t *testing.T) {
 	}
 }
 
+func TestCoupons_Get_ErrNotFound(t *testing.T) {
+	setup()
+	defer teardown()
+
+	var invoked bool
+	mux.HandleFunc("/v2/coupons/special", func(w http.ResponseWriter, r *http.Request) {
+		invoked = true
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	_, coupon, err := client.Coupons.Get("special")
+	if !invoked {
+		t.Fatal("handler not invoked")
+	} else if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	} else if coupon != nil {
+		t.Fatalf("expected coupon to be nil: %#v", coupon)
+	}
+}
+
 func TestCoupons_Create(t *testing.T) {
 	setup()
 	defer teardown()

--- a/invoices_service.go
+++ b/invoices_service.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/xml"
 	"fmt"
+	"net/http"
 	"sort"
 )
 
@@ -68,6 +69,9 @@ func (s *invoicesImpl) Get(invoiceNumber int) (*Response, *Invoice, error) {
 
 	var dst Invoice
 	resp, err := s.client.do(req, &dst)
+	if err != nil || resp.StatusCode >= http.StatusBadRequest {
+		return resp, nil, err
+	}
 
 	// Sort transactions.
 	sort.Sort(Transactions(dst.Transactions))

--- a/invoices_test.go
+++ b/invoices_test.go
@@ -513,6 +513,26 @@ func TestInvoices_Get(t *testing.T) {
 	}
 }
 
+func TestInvoices_Get_ErrNotFound(t *testing.T) {
+	setup()
+	defer teardown()
+
+	var invoked bool
+	mux.HandleFunc("/v2/invoices/1402", func(w http.ResponseWriter, r *http.Request) {
+		invoked = true
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	_, invoice, err := client.Invoices.Get(1402)
+	if !invoked {
+		t.Fatal("handler not invoked")
+	} else if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	} else if invoice != nil {
+		t.Fatalf("expected invoice to be nil: %#v", invoice)
+	}
+}
+
 // Ensures transactions are ordered by created at date.
 func TestInvoices_Get_TransactionsOrder(t *testing.T) {
 	setup()

--- a/plans_service.go
+++ b/plans_service.go
@@ -3,6 +3,7 @@ package recurly
 import (
 	"encoding/xml"
 	"fmt"
+	"net/http"
 )
 
 var _ PlansService = &plansImpl{}
@@ -46,6 +47,9 @@ func (s *plansImpl) Get(code string) (*Response, *Plan, error) {
 
 	var dst Plan
 	resp, err := s.client.do(req, &dst)
+	if err != nil || resp.StatusCode >= http.StatusBadRequest {
+		return resp, nil, err
+	}
 
 	return resp, &dst, err
 }

--- a/plans_test.go
+++ b/plans_test.go
@@ -214,6 +214,26 @@ func TestPlans_Get(t *testing.T) {
 	}
 }
 
+func TestPlans_Get_ErrNotFound(t *testing.T) {
+	setup()
+	defer teardown()
+
+	var invoked bool
+	mux.HandleFunc("/v2/plans/gold", func(w http.ResponseWriter, r *http.Request) {
+		invoked = true
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	_, plan, err := client.Plans.Get("gold")
+	if !invoked {
+		t.Fatal("handler not invoked")
+	} else if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	} else if plan != nil {
+		t.Fatalf("expected plan to be nil: %#v", plan)
+	}
+}
+
 func TestPlans_Create(t *testing.T) {
 	setup()
 	defer teardown()

--- a/redemptions_service.go
+++ b/redemptions_service.go
@@ -3,6 +3,7 @@ package recurly
 import (
 	"encoding/xml"
 	"fmt"
+	"net/http"
 )
 
 var _ RedemptionsService = &redemptionsImpl{}
@@ -30,6 +31,9 @@ func (s *redemptionsImpl) GetForAccount(accountCode string) (*Response, *Redempt
 
 	var dst Redemption
 	resp, err := s.client.do(req, &dst)
+	if err != nil || resp.StatusCode >= http.StatusBadRequest {
+		return resp, nil, err
+	}
 
 	return resp, &dst, err
 }
@@ -46,6 +50,9 @@ func (s *redemptionsImpl) GetForInvoice(invoiceNumber string) (*Response, *Redem
 
 	var dst Redemption
 	resp, err := s.client.do(req, &dst)
+	if err != nil || resp.StatusCode >= http.StatusBadRequest {
+		return resp, nil, err
+	}
 
 	return resp, &dst, err
 }

--- a/redemptions_test.go
+++ b/redemptions_test.go
@@ -53,6 +53,26 @@ func TestRedemptions_GetForAccount(t *testing.T) {
 	}
 }
 
+func TestRedemptions_GetForAccount_ErrNotFound(t *testing.T) {
+	setup()
+	defer teardown()
+
+	var invoked bool
+	mux.HandleFunc("/v2/accounts/1/redemption", func(w http.ResponseWriter, r *http.Request) {
+		invoked = true
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	_, redemption, err := client.Redemptions.GetForAccount("1")
+	if !invoked {
+		t.Fatal("handler not invoked")
+	} else if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	} else if redemption != nil {
+		t.Fatalf("expected redemption to be nil: %#v", redemption)
+	}
+}
+
 func TestRedemptions_GetForInvoice(t *testing.T) {
 	setup()
 	defer teardown()
@@ -92,6 +112,26 @@ func TestRedemptions_GetForInvoice(t *testing.T) {
 		CreatedAt:              recurly.NewTime(ts),
 	}) {
 		t.Fatalf("unexpected redemption: %v", redemption)
+	}
+}
+
+func TestRedemptions_GetForInvoice_ErrNotFound(t *testing.T) {
+	setup()
+	defer teardown()
+
+	var invoked bool
+	mux.HandleFunc("/v2/invoices/1108/redemption", func(w http.ResponseWriter, r *http.Request) {
+		invoked = true
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	_, redemption, err := client.Redemptions.GetForInvoice("1108")
+	if !invoked {
+		t.Fatal("handler not invoked")
+	} else if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	} else if redemption != nil {
+		t.Fatalf("expected redemption to be nil: %#v", redemption)
 	}
 }
 

--- a/subscriptions_service.go
+++ b/subscriptions_service.go
@@ -3,6 +3,7 @@ package recurly
 import (
 	"encoding/xml"
 	"fmt"
+	"net/http"
 	"time"
 )
 
@@ -65,6 +66,9 @@ func (s *subscriptionsImpl) Get(uuid string) (*Response, *Subscription, error) {
 
 	var dst Subscription
 	resp, err := s.client.do(req, &dst)
+	if err != nil || resp.StatusCode >= http.StatusBadRequest {
+		return resp, nil, err
+	}
 
 	return resp, &dst, err
 }

--- a/subscriptions_test.go
+++ b/subscriptions_test.go
@@ -589,6 +589,26 @@ func TestSubscriptions_Get(t *testing.T) {
 	}
 }
 
+func TestSubscriptions_Get_ErrNotFound(t *testing.T) {
+	setup()
+	defer teardown()
+
+	var invoked bool
+	mux.HandleFunc("/v2/subscriptions/44f83d7cba354d5b84812419f923ea96", func(w http.ResponseWriter, r *http.Request) {
+		invoked = true
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	_, subscription, err := client.Subscriptions.Get("44f83d7cba354d5b84812419f923ea96")
+	if !invoked {
+		t.Fatal("handler not invoked")
+	} else if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	} else if subscription != nil {
+		t.Fatalf("expected subscription to be nil: %#v", subscription)
+	}
+}
+
 func TestSubscriptions_Get_PendingSubscription(t *testing.T) {
 	setup()
 	defer teardown()

--- a/transactions_service.go
+++ b/transactions_service.go
@@ -3,6 +3,7 @@ package recurly
 import (
 	"encoding/xml"
 	"fmt"
+	"net/http"
 )
 
 var _ TransactionsService = &transactionsImpl{}
@@ -67,6 +68,9 @@ func (s *transactionsImpl) Get(uuid string) (*Response, *Transaction, error) {
 
 	var dst Transaction
 	resp, err := s.client.do(req, &dst)
+	if err != nil || resp.StatusCode >= http.StatusBadRequest {
+		return resp, nil, err
+	}
 
 	return resp, &dst, err
 }

--- a/transactions_test.go
+++ b/transactions_test.go
@@ -422,6 +422,26 @@ func TestTransactions_Get(t *testing.T) {
 	}
 }
 
+func TestTransactions_Get_ErrNotFound(t *testing.T) {
+	setup()
+	defer teardown()
+
+	var invoked bool
+	mux.HandleFunc("/v2/transactions/a13acd8fe4294916b79aec87b7ea441f", func(w http.ResponseWriter, r *http.Request) {
+		invoked = true
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	_, transaction, err := client.Transactions.Get("a13acd8fe4294916b79aec87b7ea441f")
+	if !invoked {
+		t.Fatal("handler not invoked")
+	} else if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	} else if transaction != nil {
+		t.Fatalf("expected transaction to be nil: %#v", transaction)
+	}
+}
+
 func TestTransactions_New(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
Most of the method signatures for "get" calls follow a format similar to this:

`func (s *billingImpl) Get(accountCode string) (*Response, *Billing, error)`

If an error occurs. `*Billing` (in the example above) returns a pointer to an empty initialized `Billing` struct. It should return `nil`.

This PR updates all of the "get" endpoints to return nil when a `400+` status code occurs. Also updates the client so that an `EOF` error when there is no response body to decode will not bubble back up to the caller.