### PR TITLE
webhooks: Add expired_subscription_notification

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go:
   - 1.7
-  - tip
+  - 1.8
 install: go get -v ./
 script:
     - go test -v ./...

--- a/webhooks/testdata/expired_subscription_notification.xml
+++ b/webhooks/testdata/expired_subscription_notification.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<expired_subscription_notification>
+  <account>
+    <account_code>1</account_code>
+    <username nil="true"></username>
+    <email>verena@example.com</email>
+    <first_name>Verena</first_name>
+    <last_name>Example</last_name>
+    <company_name nil="true"></company_name>
+  </account>
+  <subscription>
+    <plan>
+      <plan_code>1dpt</plan_code>
+      <name>Subscription One</name>
+    </plan>
+    <uuid>d1b6d359a01ded71caed78eaa0fedf8e</uuid>
+    <state>expired</state>
+    <quantity type="integer">1</quantity>
+    <total_amount_in_cents type="integer">200</total_amount_in_cents>
+    <subscription_add_ons type="array"/>
+    <activated_at type="datetime">2010-09-23T22:05:03Z</activated_at>
+    <canceled_at type="datetime">2010-09-23T22:05:43Z</canceled_at>
+    <expires_at type="datetime">2010-09-24T22:05:03Z</expires_at>
+    <current_period_started_at type="datetime">2010-09-23T22:05:03Z</current_period_started_at>
+    <current_period_ends_at type="datetime">2010-09-24T22:05:03Z</current_period_ends_at>
+    <trial_started_at nil="true" type="datetime"></trial_started_at>
+    <trial_ends_at nil="true" type="datetime"></trial_ends_at>
+    <collection_method>automatic</collection_method>
+  </subscription>
+</expired_subscription_notification>

--- a/webhooks/webhooks.go
+++ b/webhooks/webhooks.go
@@ -11,9 +11,10 @@ import (
 
 // Webhook notification constants.
 const (
-	SuccessfulPayment = "successful_payment_notification"
-	FailedPayment     = "failed_payment_notification"
-	PastDueInvoice    = "past_due_invoice_notification"
+	SuccessfulPayment   = "successful_payment_notification"
+	FailedPayment       = "failed_payment_notification"
+	PastDueInvoice      = "past_due_invoice_notification"
+	ExpiredSubscription = "expired_subscription_notification"
 )
 
 type notificationName struct {
@@ -22,21 +23,31 @@ type notificationName struct {
 
 type (
 	// SuccessfulPaymentNotification is sent when a payment is successful.
+	// https://dev.recurly.com/v2.4/page/webhooks#section-successful-payment
 	SuccessfulPaymentNotification struct {
 		Account     recurly.Account     `xml:"account"`
 		Transaction recurly.Transaction `xml:"transaction"`
 	}
 
 	// FailedPaymentNotification is sent when a payment fails.
+	// https://dev.recurly.com/v2.4/page/webhooks#section-failed-payment
 	FailedPaymentNotification struct {
 		Account     recurly.Account     `xml:"account"`
 		Transaction recurly.Transaction `xml:"transaction"`
 	}
 
 	// PastDueInvoiceNotification is sent when an invoice is past due.
+	// https://dev.recurly.com/v2.4/page/webhooks#section-past-due-invoice
 	PastDueInvoiceNotification struct {
 		Account recurly.Account `xml:"account"`
 		Invoice recurly.Invoice `xml:"invoice"`
+	}
+
+	// ExpiredSubscriptionNotification is sent when a subscription is no longer valid.
+	// https://dev.recurly.com/v2.4/page/webhooks#section-expired-subscription
+	ExpiredSubscriptionNotification struct {
+		Account      recurly.Account      `xml:"account"`
+		Subscription recurly.Subscription `xml:"subscription"`
 	}
 )
 
@@ -105,6 +116,8 @@ func Parse(r io.Reader) (interface{}, error) {
 		dst = &FailedPaymentNotification{}
 	case PastDueInvoice:
 		dst = &PastDueInvoiceNotification{}
+	case ExpiredSubscription:
+		dst = &ExpiredSubscriptionNotification{}
 	default:
 		return nil, ErrUnknownNotification{name: n.XMLName.Local}
 	}


### PR DESCRIPTION
Adds support for the `expired_subscription_notification`.

https://dev.recurly.com/v2.4/page/webhooks#section-expired-subscription