### PR TITLE
Add NewInvoiceNotification webhook (BLAPI-134)

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,9 +313,17 @@ TransactionError struct {
 
 ## Using webhooks
 Initial webhook support is in place. The following webhooks are supported:
+
+Subscription Notifications
+ - `ExpiredSubscriptionNotification`
+
+ Invoice Notifications
+ - `NewInvoiceNotification`
+ - `PastDueInvoiceNotification`
+
+Payment Notifications
  - `SuccessfulPaymentNotification`
  - `FailedPaymentNotification`
- - `PastDueInvoiceNotification`
 
 Webhooks can be used by passing an `io.Reader` to `webhooks.Parse`, then using a switch statement with type assertions to determine the webhook returned.
 

--- a/webhooks/testdata/new_invoice_notification.xml
+++ b/webhooks/testdata/new_invoice_notification.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<new_invoice_notification>
+  <account>
+      <account_code>1</account_code>
+      <email>verena@example.com</email>
+      <first_name>Verena</first_name>
+      <last_name>Example</last_name>
+  </account>
+  <invoice>
+    <uuid>ffc64d71d4b5404e93f13aac9c63b007</uuid>
+    <subscription_id nil="true"></subscription_id>
+    <state>open</state>
+    <invoice_number_prefix></invoice_number_prefix>
+    <invoice_number type="integer">1000</invoice_number>
+    <po_number></po_number>
+    <vat_number></vat_number>
+    <total_in_cents type="integer">1000</total_in_cents>
+    <currency>USD</currency>
+    <date type="datetime">2014-01-01T20:21:44Z</date>
+    <closed_at type="datetime" nil="true"></closed_at>
+    <net_terms type="integer">0</net_terms>
+    <collection_method>manual</collection_method>
+  </invoice>
+</new_invoice_notification>

--- a/webhooks/webhooks.go
+++ b/webhooks/webhooks.go
@@ -11,16 +11,50 @@ import (
 
 // Webhook notification constants.
 const (
-	SuccessfulPayment   = "successful_payment_notification"
-	FailedPayment       = "failed_payment_notification"
-	PastDueInvoice      = "past_due_invoice_notification"
+	// Subscription notifications.
 	ExpiredSubscription = "expired_subscription_notification"
+
+	// Invoice notifications.
+	NewInvoice     = "new_invoice_notification"
+	PastDueInvoice = "past_due_invoice_notification"
+
+	// Payment notifications.
+	SuccessfulPayment = "successful_payment_notification"
+	FailedPayment     = "failed_payment_notification"
 )
 
 type notificationName struct {
 	XMLName xml.Name
 }
 
+// Subscription types.
+type (
+	// ExpiredSubscriptionNotification is sent when a subscription is no longer valid.
+	// https://dev.recurly.com/v2.4/page/webhooks#section-expired-subscription
+	ExpiredSubscriptionNotification struct {
+		Account      recurly.Account      `xml:"account"`
+		Subscription recurly.Subscription `xml:"subscription"`
+	}
+)
+
+// Invoice types.
+type (
+	// NewInvoiceNotification is sent when an invoice generated.
+	// https://dev.recurly.com/page/webhooks#section-new-invoice
+	NewInvoiceNotification struct {
+		Account recurly.Account `xml:"account"`
+		Invoice recurly.Invoice `xml:"invoice"`
+	}
+
+	// PastDueInvoiceNotification is sent when an invoice is past due.
+	// https://dev.recurly.com/v2.4/page/webhooks#section-past-due-invoice
+	PastDueInvoiceNotification struct {
+		Account recurly.Account `xml:"account"`
+		Invoice recurly.Invoice `xml:"invoice"`
+	}
+)
+
+// Payment types.
 type (
 	// SuccessfulPaymentNotification is sent when a payment is successful.
 	// https://dev.recurly.com/v2.4/page/webhooks#section-successful-payment
@@ -34,20 +68,6 @@ type (
 	FailedPaymentNotification struct {
 		Account     recurly.Account     `xml:"account"`
 		Transaction recurly.Transaction `xml:"transaction"`
-	}
-
-	// PastDueInvoiceNotification is sent when an invoice is past due.
-	// https://dev.recurly.com/v2.4/page/webhooks#section-past-due-invoice
-	PastDueInvoiceNotification struct {
-		Account recurly.Account `xml:"account"`
-		Invoice recurly.Invoice `xml:"invoice"`
-	}
-
-	// ExpiredSubscriptionNotification is sent when a subscription is no longer valid.
-	// https://dev.recurly.com/v2.4/page/webhooks#section-expired-subscription
-	ExpiredSubscriptionNotification struct {
-		Account      recurly.Account      `xml:"account"`
-		Subscription recurly.Subscription `xml:"subscription"`
 	}
 )
 
@@ -110,14 +130,16 @@ func Parse(r io.Reader) (interface{}, error) {
 
 	var dst interface{}
 	switch n.XMLName.Local {
+	case ExpiredSubscription:
+		dst = &ExpiredSubscriptionNotification{}
+	case NewInvoice:
+		dst = &NewInvoiceNotification{}
+	case PastDueInvoice:
+		dst = &PastDueInvoiceNotification{}
 	case SuccessfulPayment:
 		dst = &SuccessfulPaymentNotification{}
 	case FailedPayment:
 		dst = &FailedPaymentNotification{}
-	case PastDueInvoice:
-		dst = &PastDueInvoiceNotification{}
-	case ExpiredSubscription:
-		dst = &ExpiredSubscriptionNotification{}
 	default:
 		return nil, ErrUnknownNotification{name: n.XMLName.Local}
 	}

--- a/webhooks/webhooks_test.go
+++ b/webhooks/webhooks_test.go
@@ -19,6 +19,106 @@ func MustOpenFile(name string) *os.File {
 	return file
 }
 
+func TestParse_ExpiredSubscriptionNotification(t *testing.T) {
+	activatedTs, _ := time.Parse(recurly.DateTimeFormat, "2010-09-23T22:05:03Z")
+	canceledTs, _ := time.Parse(recurly.DateTimeFormat, "2010-09-23T22:05:43Z")
+	expiresTs, _ := time.Parse(recurly.DateTimeFormat, "2010-09-24T22:05:03Z")
+	startedTs, _ := time.Parse(recurly.DateTimeFormat, "2010-09-23T22:05:03Z")
+	endsTs, _ := time.Parse(recurly.DateTimeFormat, "2010-09-24T22:05:03Z")
+
+	xmlFile := MustOpenFile("testdata/expired_subscription_notification.xml")
+	result, err := webhooks.Parse(xmlFile)
+	if err != nil {
+		t.Fatal(err)
+	} else if n, ok := result.(*webhooks.ExpiredSubscriptionNotification); !ok {
+		t.Fatalf("unexpected type: %T, result")
+	} else if !reflect.DeepEqual(n, &webhooks.ExpiredSubscriptionNotification{
+		Account: recurly.Account{
+			XMLName:   xml.Name{Local: "account"},
+			Code:      "1",
+			Email:     "verena@example.com",
+			FirstName: "Verena",
+			LastName:  "Example",
+		},
+		Subscription: recurly.Subscription{
+			XMLName: xml.Name{Local: "subscription"},
+			Plan: recurly.NestedPlan{
+				Code: "1dpt",
+				Name: "Subscription One",
+			},
+			UUID:                   "d1b6d359a01ded71caed78eaa0fedf8e",
+			State:                  "expired",
+			Quantity:               1,
+			ActivatedAt:            recurly.NewTime(activatedTs),
+			CanceledAt:             recurly.NewTime(canceledTs),
+			ExpiresAt:              recurly.NewTime(expiresTs),
+			CurrentPeriodStartedAt: recurly.NewTime(startedTs),
+			CurrentPeriodEndsAt:    recurly.NewTime(endsTs),
+		},
+	}) {
+		t.Fatalf("unexpected notification: %#v", n)
+	}
+}
+
+func TestParse_NewInvoiceNotification(t *testing.T) {
+	xmlFile := MustOpenFile("testdata/new_invoice_notification.xml")
+	result, err := webhooks.Parse(xmlFile)
+	if err != nil {
+		t.Fatal(err)
+	} else if n, ok := result.(*webhooks.NewInvoiceNotification); !ok {
+		t.Fatalf("unexpected type: %T, result")
+	} else if !reflect.DeepEqual(n, &webhooks.NewInvoiceNotification{
+		Account: recurly.Account{
+			XMLName:   xml.Name{Local: "account"},
+			Code:      "1",
+			Email:     "verena@example.com",
+			FirstName: "Verena",
+			LastName:  "Example",
+		},
+		Invoice: recurly.Invoice{
+			XMLName:          xml.Name{Local: "invoice"},
+			UUID:             "ffc64d71d4b5404e93f13aac9c63b007",
+			State:            "open",
+			Currency:         "USD",
+			InvoiceNumber:    1000,
+			TotalInCents:     1000,
+			NetTerms:         recurly.NullInt{Valid: true, Int: 0},
+			CollectionMethod: recurly.CollectionMethodManual,
+		},
+	}) {
+		t.Fatalf("unexpected notification: %v", n)
+	}
+}
+
+func TestParse_PastDueInvoiceNotification(t *testing.T) {
+	xmlFile := MustOpenFile("testdata/past_due_invoice_notification.xml")
+	result, err := webhooks.Parse(xmlFile)
+	if err != nil {
+		t.Fatal(err)
+	} else if n, ok := result.(*webhooks.PastDueInvoiceNotification); !ok {
+		t.Fatalf("unexpected type: %T, result")
+	} else if !reflect.DeepEqual(n, &webhooks.PastDueInvoiceNotification{
+		Account: recurly.Account{
+			XMLName:     xml.Name{Local: "account"},
+			Code:        "1",
+			Username:    "verena",
+			Email:       "verena@example.com",
+			FirstName:   "Verena",
+			LastName:    "Example",
+			CompanyName: "Company, Inc.",
+		},
+		Invoice: recurly.Invoice{
+			XMLName:       xml.Name{Local: "invoice"},
+			UUID:          "ffc64d71d4b5404e93f13aac9c63b007",
+			State:         "past_due",
+			InvoiceNumber: 1000,
+			TotalInCents:  1100,
+		},
+	}) {
+		t.Fatalf("unexpected notification: %v", n)
+	}
+}
+
 func TestParse_SuccessfulPaymentNotification(t *testing.T) {
 	xmlFile := MustOpenFile("testdata/successful_payment_notification.xml")
 	if result, err := webhooks.Parse(xmlFile); err != nil {
@@ -79,76 +179,6 @@ func TestParse_FailedPaymentNotification(t *testing.T) {
 			Test:          true,
 			Voidable:      recurly.NullBool{Bool: false, Valid: true},
 			Refundable:    recurly.NullBool{Bool: false, Valid: true},
-		},
-	}) {
-		t.Fatalf("unexpected notification: %#v", n)
-	}
-}
-
-func TestParse_PastDueInvoiceNotification(t *testing.T) {
-	xmlFile := MustOpenFile("testdata/past_due_invoice_notification.xml")
-	result, err := webhooks.Parse(xmlFile)
-	if err != nil {
-		t.Fatal(err)
-	} else if n, ok := result.(*webhooks.PastDueInvoiceNotification); !ok {
-		t.Fatalf("unexpected type: %T, result")
-	} else if !reflect.DeepEqual(n, &webhooks.PastDueInvoiceNotification{
-		Account: recurly.Account{
-			XMLName:     xml.Name{Local: "account"},
-			Code:        "1",
-			Username:    "verena",
-			Email:       "verena@example.com",
-			FirstName:   "Verena",
-			LastName:    "Example",
-			CompanyName: "Company, Inc.",
-		},
-		Invoice: recurly.Invoice{
-			XMLName:       xml.Name{Local: "invoice"},
-			UUID:          "ffc64d71d4b5404e93f13aac9c63b007",
-			State:         "past_due",
-			InvoiceNumber: 1000,
-			TotalInCents:  1100,
-		},
-	}) {
-		t.Fatalf("unexpected notification: %v", n)
-	}
-}
-
-func TestParse_ExpiredSubscriptionNotification(t *testing.T) {
-	activatedTs, _ := time.Parse(recurly.DateTimeFormat, "2010-09-23T22:05:03Z")
-	canceledTs, _ := time.Parse(recurly.DateTimeFormat, "2010-09-23T22:05:43Z")
-	expiresTs, _ := time.Parse(recurly.DateTimeFormat, "2010-09-24T22:05:03Z")
-	startedTs, _ := time.Parse(recurly.DateTimeFormat, "2010-09-23T22:05:03Z")
-	endsTs, _ := time.Parse(recurly.DateTimeFormat, "2010-09-24T22:05:03Z")
-
-	xmlFile := MustOpenFile("testdata/expired_subscription_notification.xml")
-	result, err := webhooks.Parse(xmlFile)
-	if err != nil {
-		t.Fatal(err)
-	} else if n, ok := result.(*webhooks.ExpiredSubscriptionNotification); !ok {
-		t.Fatalf("unexpected type: %T, result")
-	} else if !reflect.DeepEqual(n, &webhooks.ExpiredSubscriptionNotification{
-		Account: recurly.Account{
-			XMLName:   xml.Name{Local: "account"},
-			Code:      "1",
-			Email:     "verena@example.com",
-			FirstName: "Verena",
-			LastName:  "Example",
-		},
-		Subscription: recurly.Subscription{
-			XMLName: xml.Name{Local: "subscription"},
-			Plan: recurly.NestedPlan{
-				Code: "1dpt",
-				Name: "Subscription One",
-			},
-			UUID:                   "d1b6d359a01ded71caed78eaa0fedf8e",
-			State:                  "expired",
-			Quantity:               1,
-			ActivatedAt:            recurly.NewTime(activatedTs),
-			CanceledAt:             recurly.NewTime(canceledTs),
-			ExpiresAt:              recurly.NewTime(expiresTs),
-			CurrentPeriodStartedAt: recurly.NewTime(startedTs),
-			CurrentPeriodEndsAt:    recurly.NewTime(endsTs),
 		},
 	}) {
 		t.Fatalf("unexpected notification: %#v", n)


### PR DESCRIPTION
This PR adds the `NewInvoiceNotification` webhook. I also re-ordered the webhooks according to the order and with the same categories as the Recurly docs to make it easier to read them going forward as we add more. 

https://blacklight.atlassian.net/browse/BLAPI-134 