### PR TITLE
Webhooks: Add subscription & payment notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,11 @@ TransactionError struct {
 Initial webhook support is in place. The following webhooks are supported:
 
 Subscription Notifications
+ - `NewSubscriptionNotification`
+ - `UpdatedSubscriptionNotification`
+ - `RenewedSubscriptionNotification`
  - `ExpiredSubscriptionNotification`
+ - `CanceledSubscriptionNotification`
 
  Invoice Notifications
  - `NewInvoiceNotification`
@@ -324,6 +328,8 @@ Subscription Notifications
 Payment Notifications
  - `SuccessfulPaymentNotification`
  - `FailedPaymentNotification`
+ - `VoidPaymentNotification`
+ - `SuccessfulRefundNotification`
 
 Webhooks can be used by passing an `io.Reader` to `webhooks.Parse`, then using a switch statement with type assertions to determine the webhook returned.
 

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -41,6 +41,7 @@ type Subscription struct {
 	UnitAmountInCents      int                  `xml:"unit_amount_in_cents,omitempty"`
 	Currency               string               `xml:"currency,omitempty"`
 	Quantity               int                  `xml:"quantity,omitempty"`
+	TotalAmountInCents     int                  `xml:"total_amount_in_cents,omitempty"`
 	ActivatedAt            NullTime             `xml:"activated_at,omitempty"`
 	CanceledAt             NullTime             `xml:"canceled_at,omitempty"`
 	ExpiresAt              NullTime             `xml:"expires_at,omitempty"`
@@ -71,6 +72,7 @@ func (s *Subscription) UnmarshalXML(d *xml.Decoder, start xml.StartElement) erro
 		UnitAmountInCents      int                  `xml:"unit_amount_in_cents,omitempty"`
 		Currency               string               `xml:"currency,omitempty"`
 		Quantity               int                  `xml:"quantity,omitempty"`
+		TotalAmountInCents     int                  `xml:"total_amount_in_cents,omitempty"`
 		ActivatedAt            NullTime             `xml:"activated_at,omitempty"`
 		CanceledAt             NullTime             `xml:"canceled_at,omitempty"`
 		ExpiresAt              NullTime             `xml:"expires_at,omitempty"`
@@ -100,6 +102,7 @@ func (s *Subscription) UnmarshalXML(d *xml.Decoder, start xml.StartElement) erro
 		UnitAmountInCents:      v.UnitAmountInCents,
 		Currency:               v.Currency,
 		Quantity:               v.Quantity,
+		TotalAmountInCents:     v.TotalAmountInCents,
 		ActivatedAt:            v.ActivatedAt,
 		CanceledAt:             v.CanceledAt,
 		ExpiresAt:              v.ExpiresAt,

--- a/webhooks/testdata/canceled_subscription_notification.xml
+++ b/webhooks/testdata/canceled_subscription_notification.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<canceled_subscription_notification>
+  <account>
+    <account_code>1</account_code>
+    <username nil="true"></username>
+    <email>verena@example.com</email>
+    <first_name>Verena</first_name>
+    <last_name>Example</last_name>
+    <company_name nil="true"></company_name>
+  </account>
+  <subscription>
+    <plan>
+      <plan_code>1dpt</plan_code>
+      <name>Subscription One</name>
+    </plan>
+    <uuid>dccd742f4710e78515714d275839f891</uuid>
+    <state>canceled</state>
+    <quantity type="integer">1</quantity>
+    <total_amount_in_cents type="integer" nil="true">200</total_amount_in_cents>
+    <subscription_add_ons type="array"/>
+    <activated_at type="datetime">2010-09-23T22:05:03Z</activated_at>
+    <canceled_at type="datetime">2010-09-23T22:05:43Z</canceled_at>
+    <expires_at type="datetime">2010-09-24T22:05:03Z</expires_at>
+    <current_period_started_at type="datetime">2010-09-23T22:05:03Z</current_period_started_at>
+    <current_period_ends_at type="datetime">2010-09-24T22:05:03Z</current_period_ends_at>
+    <trial_started_at nil="true" type="datetime"></trial_started_at>
+    <trial_ends_at nil="true" type="datetime"></trial_ends_at>
+    <collection_method>automatic</collection_method>
+  </subscription>
+</canceled_subscription_notification>

--- a/webhooks/testdata/new_subscription_notification.xml
+++ b/webhooks/testdata/new_subscription_notification.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<new_subscription_notification>
+  <account>
+    <account_code>1</account_code>
+    <username nil="true"></username>
+    <email>verena@example.com</email>
+    <first_name>Verena</first_name>
+    <last_name>Example</last_name>
+    <company_name nil="true"></company_name>
+  </account>
+  <subscription>
+    <plan>
+      <plan_code>bronze</plan_code>
+      <name>Bronze Plan</name>
+    </plan>
+    <uuid>d1b6d359a01ded71caed78eaa0fedf8e</uuid>
+    <state>active</state>
+    <quantity type="integer">2</quantity>
+    <total_amount_in_cents type="integer">17000</total_amount_in_cents>
+    <subscription_add_ons type="array"/>
+    <activated_at type="datetime">2010-09-23T22:05:03Z</activated_at>
+    <canceled_at type="datetime">2010-09-23T22:05:43Z</canceled_at>
+    <expires_at type="datetime">2010-09-24T22:05:03Z</expires_at>
+    <current_period_started_at type="datetime">2010-09-23T22:05:03Z</current_period_started_at>
+    <current_period_ends_at type="datetime">2010-09-24T22:05:03Z</current_period_ends_at>
+    <trial_started_at nil="true" type="datetime"></trial_started_at>
+    <trial_ends_at nil="true" type="datetime"></trial_ends_at>
+    <collection_method>automatic</collection_method>
+  </subscription>
+</new_subscription_notification>

--- a/webhooks/testdata/renewed_subscription_notification.xml
+++ b/webhooks/testdata/renewed_subscription_notification.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<renewed_subscription_notification>
+  <account>
+    <account_code>1</account_code>
+    <username nil="true"></username>
+    <email>verena@example.com</email>
+    <first_name>Verena</first_name>
+    <last_name>Example</last_name>
+    <company_name>Company, Inc.</company_name>
+  </account>
+  <subscription>
+    <plan>
+      <plan_code>bootstrap</plan_code>
+      <name>Bootstrap</name>
+    </plan>
+    <uuid>6ab458a887d38070807ebb3bed7ac1e5</uuid>
+    <state>active</state>
+    <quantity type="integer">1</quantity>
+    <total_amount_in_cents type="integer">9900</total_amount_in_cents>
+    <subscription_add_ons type="array"/>
+    <activated_at type="datetime">2010-07-22T20:42:05Z</activated_at>
+    <canceled_at nil="true" type="datetime"></canceled_at>
+    <expires_at nil="true" type="datetime"></expires_at>
+    <current_period_started_at type="datetime">2010-09-22T20:42:05Z</current_period_started_at>
+    <current_period_ends_at type="datetime">2010-10-22T20:42:05Z</current_period_ends_at>
+    <trial_started_at nil="true" type="datetime"></trial_started_at>
+    <trial_ends_at nil="true" type="datetime"></trial_ends_at>
+    <collection_method>automatic</collection_method>
+  </subscription>
+</renewed_subscription_notification>

--- a/webhooks/testdata/successful_refund_notification.xml
+++ b/webhooks/testdata/successful_refund_notification.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<successful_refund_notification>
+  <account>
+    <account_code>1</account_code>
+    <username nil="true">verena</username>
+    <email>verena@example.com</email>
+    <first_name>Verena</first_name>
+    <last_name>Example</last_name>
+    <company_name nil="true">Company, Inc.</company_name>
+  </account>
+  <transaction>
+    <id>a5143c1d3a6f4a8287d0e2cc1d4c0427</id>
+    <invoice_id>ffc64d71d4b5404e93f13aac9c63b007</invoice_id>
+    <invoice_number type="integer">2059</invoice_number>
+    <subscription_id>1974a098jhlkjasdfljkha898326881c</subscription_id>
+    <action>credit</action>
+    <date type="datetime">2010-10-06T20:37:55Z</date>
+    <amount_in_cents type="integer">1000</amount_in_cents>
+    <status>success</status>
+    <message>Bogus Gateway: Forced success</message>
+    <reference>reference</reference>
+    <source>subscription</source>
+    <cvv_result code=""></cvv_result>
+    <avs_result code=""></avs_result>
+    <avs_result_street></avs_result_street>
+    <avs_result_postal></avs_result_postal>
+    <test type="boolean">true</test>
+    <voidable type="boolean">true</voidable>
+    <refundable type="boolean">true</refundable>
+  </transaction>
+</successful_refund_notification>

--- a/webhooks/testdata/updated_subscription_notification.xml
+++ b/webhooks/testdata/updated_subscription_notification.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<updated_subscription_notification>
+  <account>
+    <account_code>1</account_code>
+    <username nil="true"></username>
+    <email>verena@example.com</email>
+    <first_name>Verena</first_name>
+    <last_name>Example</last_name>
+    <company_name nil="true"></company_name>
+  </account>
+  <subscription>
+    <plan>
+      <plan_code>1dpt</plan_code>
+      <name>Subscription One</name>
+    </plan>
+    <uuid>292332928954ca62fa48048be5ac98ec</uuid>
+    <state>active</state>
+    <quantity type="integer">1</quantity>
+    <total_amount_in_cents type="integer">200</total_amount_in_cents>
+    <subscription_add_ons type="array"/>
+    <activated_at type="datetime">2010-09-23T22:05:03Z</activated_at>
+    <canceled_at type="datetime">2010-09-23T22:05:43Z</canceled_at>
+    <expires_at type="datetime">2010-09-24T22:05:03Z</expires_at>
+    <current_period_started_at type="datetime">2010-09-23T22:05:03Z</current_period_started_at>
+    <current_period_ends_at type="datetime">2010-09-24T22:05:03Z</current_period_ends_at>
+    <trial_started_at nil="true" type="datetime"></trial_started_at>
+    <trial_ends_at nil="true" type="datetime"></trial_ends_at>
+    <collection_method>automatic</collection_method>
+  </subscription>
+</updated_subscription_notification>

--- a/webhooks/testdata/void_payment_notification.xml
+++ b/webhooks/testdata/void_payment_notification.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<void_payment_notification>
+  <account>
+    <account_code>1</account_code>
+    <username nil="true">verena</username>
+    <email>verena@example.com</email>
+    <first_name>Verena</first_name>
+    <last_name>Example</last_name>
+    <company_name nil="true">Company, Inc.</company_name>
+  </account>
+  <transaction>
+    <id>a5143c1d3a6f4a8287d0e2cc1d4c0427</id>
+    <invoice_id>ffc64d71d4b5404e93f13aac9c63b007</invoice_id>
+    <invoice_number type="integer">2059</invoice_number>
+    <subscription_id>1974a098jhlkjasdfljkha898326881c</subscription_id>
+    <action>purchase</action>
+    <date type="datetime">2010-10-05T23:00:50Z</date>
+    <amount_in_cents type="integer">1000</amount_in_cents>
+    <status>void</status>
+    <message>Test Gateway: Successful test transaction</message>
+    <reference>reference</reference>
+    <source>subscription</source>
+    <cvv_result code=""></cvv_result>
+    <avs_result code=""></avs_result>
+    <avs_result_street></avs_result_street>
+    <avs_result_postal></avs_result_postal>
+    <test type="boolean">true</test>
+    <voidable type="boolean">true</voidable>
+    <refundable type="boolean">true</refundable>
+  </transaction>
+</void_payment_notification>

--- a/webhooks/webhooks_test.go
+++ b/webhooks/webhooks_test.go
@@ -19,6 +19,129 @@ func MustOpenFile(name string) *os.File {
 	return file
 }
 
+func TestParse_NewSubscriptionNotification(t *testing.T) {
+	activatedTs, _ := time.Parse(recurly.DateTimeFormat, "2010-09-23T22:05:03Z")
+	canceledTs, _ := time.Parse(recurly.DateTimeFormat, "2010-09-23T22:05:43Z")
+	expiresTs, _ := time.Parse(recurly.DateTimeFormat, "2010-09-24T22:05:03Z")
+	startedTs, _ := time.Parse(recurly.DateTimeFormat, "2010-09-23T22:05:03Z")
+	endsTs, _ := time.Parse(recurly.DateTimeFormat, "2010-09-24T22:05:03Z")
+
+	xmlFile := MustOpenFile("testdata/new_subscription_notification.xml")
+	result, err := webhooks.Parse(xmlFile)
+	if err != nil {
+		t.Fatal(err)
+	} else if n, ok := result.(*webhooks.NewSubscriptionNotification); !ok {
+		t.Fatalf("unexpected type: %T, result")
+	} else if !reflect.DeepEqual(n, &webhooks.NewSubscriptionNotification{
+		Account: recurly.Account{
+			XMLName:   xml.Name{Local: "account"},
+			Code:      "1",
+			Email:     "verena@example.com",
+			FirstName: "Verena",
+			LastName:  "Example",
+		},
+		Subscription: recurly.Subscription{
+			XMLName: xml.Name{Local: "subscription"},
+			Plan: recurly.NestedPlan{
+				Code: "bronze",
+				Name: "Bronze Plan",
+			},
+			UUID:                   "d1b6d359a01ded71caed78eaa0fedf8e",
+			State:                  "active",
+			Quantity:               2,
+			TotalAmountInCents:     17000,
+			ActivatedAt:            recurly.NewTime(activatedTs),
+			CanceledAt:             recurly.NewTime(canceledTs),
+			ExpiresAt:              recurly.NewTime(expiresTs),
+			CurrentPeriodStartedAt: recurly.NewTime(startedTs),
+			CurrentPeriodEndsAt:    recurly.NewTime(endsTs),
+		},
+	}) {
+		t.Fatalf("unexpected notification: %#v", n)
+	}
+}
+
+func TestParse_UpdatedSubscriptionNotification(t *testing.T) {
+	activatedTs, _ := time.Parse(recurly.DateTimeFormat, "2010-09-23T22:05:03Z")
+	canceledTs, _ := time.Parse(recurly.DateTimeFormat, "2010-09-23T22:05:43Z")
+	expiresTs, _ := time.Parse(recurly.DateTimeFormat, "2010-09-24T22:05:03Z")
+	startedTs, _ := time.Parse(recurly.DateTimeFormat, "2010-09-23T22:05:03Z")
+	endsTs, _ := time.Parse(recurly.DateTimeFormat, "2010-09-24T22:05:03Z")
+
+	xmlFile := MustOpenFile("testdata/updated_subscription_notification.xml")
+	result, err := webhooks.Parse(xmlFile)
+	if err != nil {
+		t.Fatal(err)
+	} else if n, ok := result.(*webhooks.UpdatedSubscriptionNotification); !ok {
+		t.Fatalf("unexpected type: %T, result")
+	} else if !reflect.DeepEqual(n, &webhooks.UpdatedSubscriptionNotification{
+		Account: recurly.Account{
+			XMLName:   xml.Name{Local: "account"},
+			Code:      "1",
+			Email:     "verena@example.com",
+			FirstName: "Verena",
+			LastName:  "Example",
+		},
+		Subscription: recurly.Subscription{
+			XMLName: xml.Name{Local: "subscription"},
+			Plan: recurly.NestedPlan{
+				Code: "1dpt",
+				Name: "Subscription One",
+			},
+			UUID:                   "292332928954ca62fa48048be5ac98ec",
+			State:                  "active",
+			Quantity:               1,
+			TotalAmountInCents:     200,
+			ActivatedAt:            recurly.NewTime(activatedTs),
+			CanceledAt:             recurly.NewTime(canceledTs),
+			ExpiresAt:              recurly.NewTime(expiresTs),
+			CurrentPeriodStartedAt: recurly.NewTime(startedTs),
+			CurrentPeriodEndsAt:    recurly.NewTime(endsTs),
+		},
+	}) {
+		t.Fatalf("unexpected notification: %#v", n)
+	}
+}
+
+func TestParse_RenewedSubscriptionNotification(t *testing.T) {
+	activatedTs, _ := time.Parse(recurly.DateTimeFormat, "2010-07-22T20:42:05Z")
+	startedTs, _ := time.Parse(recurly.DateTimeFormat, "2010-09-22T20:42:05Z")
+	endsTs, _ := time.Parse(recurly.DateTimeFormat, "2010-10-22T20:42:05Z")
+
+	xmlFile := MustOpenFile("testdata/renewed_subscription_notification.xml")
+	result, err := webhooks.Parse(xmlFile)
+	if err != nil {
+		t.Fatal(err)
+	} else if n, ok := result.(*webhooks.RenewedSubscriptionNotification); !ok {
+		t.Fatalf("unexpected type: %T, result")
+	} else if !reflect.DeepEqual(n, &webhooks.RenewedSubscriptionNotification{
+		Account: recurly.Account{
+			XMLName:     xml.Name{Local: "account"},
+			Code:        "1",
+			Email:       "verena@example.com",
+			FirstName:   "Verena",
+			LastName:    "Example",
+			CompanyName: "Company, Inc.",
+		},
+		Subscription: recurly.Subscription{
+			XMLName: xml.Name{Local: "subscription"},
+			Plan: recurly.NestedPlan{
+				Code: "bootstrap",
+				Name: "Bootstrap",
+			},
+			UUID:                   "6ab458a887d38070807ebb3bed7ac1e5",
+			State:                  "active",
+			Quantity:               1,
+			TotalAmountInCents:     9900,
+			ActivatedAt:            recurly.NewTime(activatedTs),
+			CurrentPeriodStartedAt: recurly.NewTime(startedTs),
+			CurrentPeriodEndsAt:    recurly.NewTime(endsTs),
+		},
+	}) {
+		t.Fatalf("unexpected notification: %#v", n)
+	}
+}
+
 func TestParse_ExpiredSubscriptionNotification(t *testing.T) {
 	activatedTs, _ := time.Parse(recurly.DateTimeFormat, "2010-09-23T22:05:03Z")
 	canceledTs, _ := time.Parse(recurly.DateTimeFormat, "2010-09-23T22:05:43Z")
@@ -49,6 +172,49 @@ func TestParse_ExpiredSubscriptionNotification(t *testing.T) {
 			UUID:                   "d1b6d359a01ded71caed78eaa0fedf8e",
 			State:                  "expired",
 			Quantity:               1,
+			TotalAmountInCents:     200,
+			ActivatedAt:            recurly.NewTime(activatedTs),
+			CanceledAt:             recurly.NewTime(canceledTs),
+			ExpiresAt:              recurly.NewTime(expiresTs),
+			CurrentPeriodStartedAt: recurly.NewTime(startedTs),
+			CurrentPeriodEndsAt:    recurly.NewTime(endsTs),
+		},
+	}) {
+		t.Fatalf("unexpected notification: %#v", n)
+	}
+}
+
+func TestParse_CanceledSubscriptionNotification(t *testing.T) {
+	activatedTs, _ := time.Parse(recurly.DateTimeFormat, "2010-09-23T22:05:03Z")
+	canceledTs, _ := time.Parse(recurly.DateTimeFormat, "2010-09-23T22:05:43Z")
+	expiresTs, _ := time.Parse(recurly.DateTimeFormat, "2010-09-24T22:05:03Z")
+	startedTs, _ := time.Parse(recurly.DateTimeFormat, "2010-09-23T22:05:03Z")
+	endsTs, _ := time.Parse(recurly.DateTimeFormat, "2010-09-24T22:05:03Z")
+
+	xmlFile := MustOpenFile("testdata/canceled_subscription_notification.xml")
+	result, err := webhooks.Parse(xmlFile)
+	if err != nil {
+		t.Fatal(err)
+	} else if n, ok := result.(*webhooks.CanceledSubscriptionNotification); !ok {
+		t.Fatalf("unexpected type: %T, result")
+	} else if !reflect.DeepEqual(n, &webhooks.CanceledSubscriptionNotification{
+		Account: recurly.Account{
+			XMLName:   xml.Name{Local: "account"},
+			Code:      "1",
+			Email:     "verena@example.com",
+			FirstName: "Verena",
+			LastName:  "Example",
+		},
+		Subscription: recurly.Subscription{
+			XMLName: xml.Name{Local: "subscription"},
+			Plan: recurly.NestedPlan{
+				Code: "1dpt",
+				Name: "Subscription One",
+			},
+			UUID:                   "dccd742f4710e78515714d275839f891",
+			State:                  "canceled",
+			Quantity:               1,
+			TotalAmountInCents:     200,
 			ActivatedAt:            recurly.NewTime(activatedTs),
 			CanceledAt:             recurly.NewTime(canceledTs),
 			ExpiresAt:              recurly.NewTime(expiresTs),
@@ -179,6 +345,72 @@ func TestParse_FailedPaymentNotification(t *testing.T) {
 			Test:          true,
 			Voidable:      recurly.NullBool{Bool: false, Valid: true},
 			Refundable:    recurly.NullBool{Bool: false, Valid: true},
+		},
+	}) {
+		t.Fatalf("unexpected notification: %#v", n)
+	}
+}
+
+func TestParse_VoidPaymentNotification(t *testing.T) {
+	xmlFile := MustOpenFile("testdata/void_payment_notification.xml")
+	if result, err := webhooks.Parse(xmlFile); err != nil {
+		t.Fatal(err)
+	} else if n, ok := result.(*webhooks.VoidPaymentNotification); !ok {
+		t.Fatalf("unexpected type: %T, result")
+	} else if !reflect.DeepEqual(n, &webhooks.VoidPaymentNotification{
+		Account: recurly.Account{
+			XMLName:     xml.Name{Local: "account"},
+			Code:        "1",
+			Username:    "verena",
+			Email:       "verena@example.com",
+			FirstName:   "Verena",
+			LastName:    "Example",
+			CompanyName: "Company, Inc.",
+		},
+		Transaction: recurly.Transaction{
+			UUID:          "a5143c1d3a6f4a8287d0e2cc1d4c0427",
+			InvoiceNumber: 2059,
+			Action:        "purchase",
+			AmountInCents: 1000,
+			Status:        "void",
+			Reference:     "reference",
+			Source:        "subscription",
+			Test:          true,
+			Voidable:      recurly.NullBool{Bool: true, Valid: true},
+			Refundable:    recurly.NullBool{Bool: true, Valid: true},
+		},
+	}) {
+		t.Fatalf("unexpected notification: %#v", n)
+	}
+}
+
+func TestParse_SuccessfulRefundNotification(t *testing.T) {
+	xmlFile := MustOpenFile("testdata/successful_refund_notification.xml")
+	if result, err := webhooks.Parse(xmlFile); err != nil {
+		t.Fatal(err)
+	} else if n, ok := result.(*webhooks.SuccessfulRefundNotification); !ok {
+		t.Fatalf("unexpected type: %T, result")
+	} else if !reflect.DeepEqual(n, &webhooks.SuccessfulRefundNotification{
+		Account: recurly.Account{
+			XMLName:     xml.Name{Local: "account"},
+			Code:        "1",
+			Username:    "verena",
+			Email:       "verena@example.com",
+			FirstName:   "Verena",
+			LastName:    "Example",
+			CompanyName: "Company, Inc.",
+		},
+		Transaction: recurly.Transaction{
+			UUID:          "a5143c1d3a6f4a8287d0e2cc1d4c0427",
+			InvoiceNumber: 2059,
+			Action:        "credit",
+			AmountInCents: 1000,
+			Status:        "success",
+			Reference:     "reference",
+			Source:        "subscription",
+			Test:          true,
+			Voidable:      recurly.NullBool{Bool: true, Valid: true},
+			Refundable:    recurly.NullBool{Bool: true, Valid: true},
 		},
 	}) {
 		t.Fatalf("unexpected notification: %#v", n)


### PR DESCRIPTION
Added support for the following webhooks:

- New Subscription Notification
- Updated Subscription Notification
- Renewed Subscription Notification
- Void Payment Notification
- Successful Refund Notification

Tests included.