### PR TITLE
Use custom account and transaction structs for webhooks

### DIFF
--- a/webhooks/testdata/failed_payment_notification.xml
+++ b/webhooks/testdata/failed_payment_notification.xml
@@ -17,6 +17,7 @@
     <date type="datetime">2009-11-22T13:10:38Z</date>
     <gateway>cybersource</gateway>
     <amount_in_cents type="integer">1000</amount_in_cents>
+    <payment_method>credit_card</payment_method>
     <status>Declined</status>
     <message>This transaction has been declined</message>
     <gateway_error_codes nil="true"></gateway_error_codes>

--- a/webhooks/webhooks.go
+++ b/webhooks/webhooks.go
@@ -47,21 +47,21 @@ type Account struct {
 
 // Transaction represents the transaction object sent in webhooks.
 type Transaction struct {
-	XMLName           xml.Name `xml:"transaction"`
-	UUID              string   `xml:"id,omitempty"`
-	InvoiceNumber     int      `xml:"invoice_number,omitempty"`
-	SubscriptionUUID  string   `xml:"subscription_id,omitempty"`
-	Action            string   `xml:"action,omitempty"`
-	AmountInCents     int      `xml:"amount_in_cents,omitempty"`
-	Status            string   `xml:"status,omitempty"`
-	Message           string   `xml:"message,omitempty"`
-	GatewayErrorCodes string   `xml:"gateway_error_codes,omitempty"`
-	FailureType       string   `xml:"failure_type,omitempty"`
-	Reference         string   `xml:"reference,omitempty"`
-	Source            string   `xml:"source,omitempty"`
-	Test              bool     `xml:"test,omitempty"`
-	Voidable          bool     `xml:"voidable,omitempty"`
-	Refundable        bool     `xml:"refundable,omitempty"`
+	XMLName           xml.Name         `xml:"transaction"`
+	UUID              string           `xml:"id,omitempty"`
+	InvoiceNumber     int              `xml:"invoice_number,omitempty"`
+	SubscriptionUUID  string           `xml:"subscription_id,omitempty"`
+	Action            string           `xml:"action,omitempty"`
+	AmountInCents     int              `xml:"amount_in_cents,omitempty"`
+	Status            string           `xml:"status,omitempty"`
+	Message           string           `xml:"message,omitempty"`
+	GatewayErrorCodes string           `xml:"gateway_error_codes,omitempty"`
+	FailureType       string           `xml:"failure_type,omitempty"`
+	Reference         string           `xml:"reference,omitempty"`
+	Source            string           `xml:"source,omitempty"`
+	Test              recurly.NullBool `xml:"test,omitempty"`
+	Voidable          recurly.NullBool `xml:"voidable,omitempty"`
+	Refundable        recurly.NullBool `xml:"refundable,omitempty"`
 }
 
 // Transaction constants.

--- a/webhooks/webhooks.go
+++ b/webhooks/webhooks.go
@@ -64,6 +64,12 @@ type Transaction struct {
 	Refundable        bool     `xml:"refundable,omitempty"`
 }
 
+// Transaction constants.
+const (
+	TransactionFailureTypeDeclined  = "declined"
+	TransactionFailureTypeDuplicate = "duplicate_transaction"
+)
+
 // Subscription types.
 type (
 	// NewSubscriptionNotification is sent when a new subscription is created.

--- a/webhooks/webhooks_test.go
+++ b/webhooks/webhooks_test.go
@@ -292,7 +292,7 @@ func TestParse_SuccessfulPaymentNotification(t *testing.T) {
 	} else if n, ok := result.(*webhooks.SuccessfulPaymentNotification); !ok {
 		t.Fatalf("unexpected type: %T, result")
 	} else if !reflect.DeepEqual(n, &webhooks.SuccessfulPaymentNotification{
-		Account: recurly.Account{
+		Account: webhooks.Account{
 			XMLName:     xml.Name{Local: "account"},
 			Code:        "1",
 			Username:    "verena",
@@ -301,17 +301,19 @@ func TestParse_SuccessfulPaymentNotification(t *testing.T) {
 			LastName:    "Example",
 			CompanyName: "Company, Inc.",
 		},
-		Transaction: recurly.Transaction{
+		Transaction: webhooks.Transaction{
+			XMLName:       xml.Name{Local: "transaction"},
 			UUID:          "a5143c1d3a6f4a8287d0e2cc1d4c0427",
 			InvoiceNumber: 2059,
 			Action:        "purchase",
 			AmountInCents: 1000,
 			Status:        "success",
+			Message:       "Bogus Gateway: Forced success",
 			Reference:     "reference",
 			Source:        "subscription",
 			Test:          true,
-			Voidable:      recurly.NullBool{Bool: true, Valid: true},
-			Refundable:    recurly.NullBool{Bool: true, Valid: true},
+			Voidable:      true,
+			Refundable:    true,
 		},
 	}) {
 		t.Fatalf("unexpected notification: %#v", n)
@@ -325,7 +327,7 @@ func TestParse_FailedPaymentNotification(t *testing.T) {
 	} else if n, ok := result.(*webhooks.FailedPaymentNotification); !ok {
 		t.Fatalf("unexpected type: %T, result")
 	} else if !reflect.DeepEqual(n, &webhooks.FailedPaymentNotification{
-		Account: recurly.Account{
+		Account: webhooks.Account{
 			XMLName:     xml.Name{Local: "account"},
 			Code:        "1",
 			Username:    "verena",
@@ -334,17 +336,21 @@ func TestParse_FailedPaymentNotification(t *testing.T) {
 			LastName:    "Example",
 			CompanyName: "Company, Inc.",
 		},
-		Transaction: recurly.Transaction{
-			UUID:          "a5143c1d3a6f4a8287d0e2cc1d4c0427",
-			InvoiceNumber: 2059,
-			Action:        "purchase",
-			AmountInCents: 1000,
-			Status:        "Declined",
-			Reference:     "reference",
-			Source:        "subscription",
-			Test:          true,
-			Voidable:      recurly.NullBool{Bool: false, Valid: true},
-			Refundable:    recurly.NullBool{Bool: false, Valid: true},
+		Transaction: webhooks.Transaction{
+			XMLName:          xml.Name{Local: "transaction"},
+			UUID:             "a5143c1d3a6f4a8287d0e2cc1d4c0427",
+			InvoiceNumber:    2059,
+			SubscriptionUUID: "1974a098jhlkjasdfljkha898326881c",
+			Action:           "purchase",
+			AmountInCents:    1000,
+			Status:           "Declined",
+			Message:          "This transaction has been declined",
+			FailureType:      "Declined by the gateway",
+			Reference:        "reference",
+			Source:           "subscription",
+			Test:             true,
+			Voidable:         false,
+			Refundable:       false,
 		},
 	}) {
 		t.Fatalf("unexpected notification: %#v", n)
@@ -358,7 +364,7 @@ func TestParse_VoidPaymentNotification(t *testing.T) {
 	} else if n, ok := result.(*webhooks.VoidPaymentNotification); !ok {
 		t.Fatalf("unexpected type: %T, result")
 	} else if !reflect.DeepEqual(n, &webhooks.VoidPaymentNotification{
-		Account: recurly.Account{
+		Account: webhooks.Account{
 			XMLName:     xml.Name{Local: "account"},
 			Code:        "1",
 			Username:    "verena",
@@ -367,17 +373,20 @@ func TestParse_VoidPaymentNotification(t *testing.T) {
 			LastName:    "Example",
 			CompanyName: "Company, Inc.",
 		},
-		Transaction: recurly.Transaction{
-			UUID:          "a5143c1d3a6f4a8287d0e2cc1d4c0427",
-			InvoiceNumber: 2059,
-			Action:        "purchase",
-			AmountInCents: 1000,
-			Status:        "void",
-			Reference:     "reference",
-			Source:        "subscription",
-			Test:          true,
-			Voidable:      recurly.NullBool{Bool: true, Valid: true},
-			Refundable:    recurly.NullBool{Bool: true, Valid: true},
+		Transaction: webhooks.Transaction{
+			XMLName:          xml.Name{Local: "transaction"},
+			UUID:             "a5143c1d3a6f4a8287d0e2cc1d4c0427",
+			InvoiceNumber:    2059,
+			SubscriptionUUID: "1974a098jhlkjasdfljkha898326881c",
+			Action:           "purchase",
+			AmountInCents:    1000,
+			Status:           "void",
+			Message:          "Test Gateway: Successful test transaction",
+			Reference:        "reference",
+			Source:           "subscription",
+			Test:             true,
+			Voidable:         true,
+			Refundable:       true,
 		},
 	}) {
 		t.Fatalf("unexpected notification: %#v", n)
@@ -391,7 +400,7 @@ func TestParse_SuccessfulRefundNotification(t *testing.T) {
 	} else if n, ok := result.(*webhooks.SuccessfulRefundNotification); !ok {
 		t.Fatalf("unexpected type: %T, result")
 	} else if !reflect.DeepEqual(n, &webhooks.SuccessfulRefundNotification{
-		Account: recurly.Account{
+		Account: webhooks.Account{
 			XMLName:     xml.Name{Local: "account"},
 			Code:        "1",
 			Username:    "verena",
@@ -400,17 +409,20 @@ func TestParse_SuccessfulRefundNotification(t *testing.T) {
 			LastName:    "Example",
 			CompanyName: "Company, Inc.",
 		},
-		Transaction: recurly.Transaction{
-			UUID:          "a5143c1d3a6f4a8287d0e2cc1d4c0427",
-			InvoiceNumber: 2059,
-			Action:        "credit",
-			AmountInCents: 1000,
-			Status:        "success",
-			Reference:     "reference",
-			Source:        "subscription",
-			Test:          true,
-			Voidable:      recurly.NullBool{Bool: true, Valid: true},
-			Refundable:    recurly.NullBool{Bool: true, Valid: true},
+		Transaction: webhooks.Transaction{
+			XMLName:          xml.Name{Local: "transaction"},
+			UUID:             "a5143c1d3a6f4a8287d0e2cc1d4c0427",
+			InvoiceNumber:    2059,
+			SubscriptionUUID: "1974a098jhlkjasdfljkha898326881c",
+			Action:           "credit",
+			AmountInCents:    1000,
+			Status:           "success",
+			Message:          "Bogus Gateway: Forced success",
+			Reference:        "reference",
+			Source:           "subscription",
+			Test:             true,
+			Voidable:         true,
+			Refundable:       true,
 		},
 	}) {
 		t.Fatalf("unexpected notification: %#v", n)

--- a/webhooks/webhooks_test.go
+++ b/webhooks/webhooks_test.go
@@ -311,9 +311,9 @@ func TestParse_SuccessfulPaymentNotification(t *testing.T) {
 			Message:       "Bogus Gateway: Forced success",
 			Reference:     "reference",
 			Source:        "subscription",
-			Test:          true,
-			Voidable:      true,
-			Refundable:    true,
+			Test:          recurly.NullBool{Valid: true, Bool: true},
+			Voidable:      recurly.NullBool{Valid: true, Bool: true},
+			Refundable:    recurly.NullBool{Valid: true, Bool: true},
 		},
 	}) {
 		t.Fatalf("unexpected notification: %#v", n)
@@ -348,9 +348,9 @@ func TestParse_FailedPaymentNotification(t *testing.T) {
 			FailureType:      "Declined by the gateway",
 			Reference:        "reference",
 			Source:           "subscription",
-			Test:             true,
-			Voidable:         false,
-			Refundable:       false,
+			Test:             recurly.NullBool{Valid: true, Bool: true},
+			Voidable:         recurly.NullBool{Valid: true, Bool: false},
+			Refundable:       recurly.NullBool{Valid: true, Bool: false},
 		},
 	}) {
 		t.Fatalf("unexpected notification: %#v", n)
@@ -384,9 +384,9 @@ func TestParse_VoidPaymentNotification(t *testing.T) {
 			Message:          "Test Gateway: Successful test transaction",
 			Reference:        "reference",
 			Source:           "subscription",
-			Test:             true,
-			Voidable:         true,
-			Refundable:       true,
+			Test:             recurly.NullBool{Valid: true, Bool: true},
+			Voidable:         recurly.NullBool{Valid: true, Bool: true},
+			Refundable:       recurly.NullBool{Valid: true, Bool: true},
 		},
 	}) {
 		t.Fatalf("unexpected notification: %#v", n)
@@ -420,9 +420,9 @@ func TestParse_SuccessfulRefundNotification(t *testing.T) {
 			Message:          "Bogus Gateway: Forced success",
 			Reference:        "reference",
 			Source:           "subscription",
-			Test:             true,
-			Voidable:         true,
-			Refundable:       true,
+			Test:             recurly.NullBool{Valid: true, Bool: true},
+			Voidable:         recurly.NullBool{Valid: true, Bool: true},
+			Refundable:       recurly.NullBool{Valid: true, Bool: true},
 		},
 	}) {
 		t.Fatalf("unexpected notification: %#v", n)


### PR DESCRIPTION
The objects sent with webhooks are not the same as the object used throughout the rest of the project. This PR adds custom webhooks structs for `Account` and `Transaction` (the rest can be updated later) so that all the relevant fields are returned for transaction webhooks. 