### PR TITLE
Updated notification structs to use webhook-specific account struct

### DIFF
--- a/webhooks/webhooks.go
+++ b/webhooks/webhooks.go
@@ -75,35 +75,35 @@ type (
 	// NewSubscriptionNotification is sent when a new subscription is created.
 	// https://dev.recurly.com/page/webhooks#section-new-subscription
 	NewSubscriptionNotification struct {
-		Account      recurly.Account      `xml:"account"`
+		Account      Account              `xml:"account"`
 		Subscription recurly.Subscription `xml:"subscription"`
 	}
 
 	// UpdatedSubscriptionNotification is sent when a subscription is upgraded or downgraded.
 	// https://dev.recurly.com/page/webhooks#section-updated-subscription
 	UpdatedSubscriptionNotification struct {
-		Account      recurly.Account      `xml:"account"`
+		Account      Account              `xml:"account"`
 		Subscription recurly.Subscription `xml:"subscription"`
 	}
 
 	// RenewedSubscriptionNotification is sent when a subscription renew.
 	// https://dev.recurly.com/page/webhooks#section-renewed-subscription
 	RenewedSubscriptionNotification struct {
-		Account      recurly.Account      `xml:"account"`
+		Account      Account              `xml:"account"`
 		Subscription recurly.Subscription `xml:"subscription"`
 	}
 
 	// ExpiredSubscriptionNotification is sent when a subscription is no longer valid.
 	// https://dev.recurly.com/v2.4/page/webhooks#section-expired-subscription
 	ExpiredSubscriptionNotification struct {
-		Account      recurly.Account      `xml:"account"`
+		Account      Account              `xml:"account"`
 		Subscription recurly.Subscription `xml:"subscription"`
 	}
 
 	// CanceledSubscriptionNotification is sent when a subscription is canceled.
 	// https://dev.recurly.com/page/webhooks#section-canceled-subscription
 	CanceledSubscriptionNotification struct {
-		Account      recurly.Account      `xml:"account"`
+		Account      Account              `xml:"account"`
 		Subscription recurly.Subscription `xml:"subscription"`
 	}
 )
@@ -113,14 +113,14 @@ type (
 	// NewInvoiceNotification is sent when an invoice generated.
 	// https://dev.recurly.com/page/webhooks#section-new-invoice
 	NewInvoiceNotification struct {
-		Account recurly.Account `xml:"account"`
+		Account Account         `xml:"account"`
 		Invoice recurly.Invoice `xml:"invoice"`
 	}
 
 	// PastDueInvoiceNotification is sent when an invoice is past due.
 	// https://dev.recurly.com/v2.4/page/webhooks#section-past-due-invoice
 	PastDueInvoiceNotification struct {
-		Account recurly.Account `xml:"account"`
+		Account Account         `xml:"account"`
 		Invoice recurly.Invoice `xml:"invoice"`
 	}
 )

--- a/webhooks/webhooks_test.go
+++ b/webhooks/webhooks_test.go
@@ -33,7 +33,7 @@ func TestParse_NewSubscriptionNotification(t *testing.T) {
 	} else if n, ok := result.(*webhooks.NewSubscriptionNotification); !ok {
 		t.Fatalf("unexpected type: %T, result")
 	} else if !reflect.DeepEqual(n, &webhooks.NewSubscriptionNotification{
-		Account: recurly.Account{
+		Account: webhooks.Account{
 			XMLName:   xml.Name{Local: "account"},
 			Code:      "1",
 			Email:     "verena@example.com",
@@ -75,7 +75,7 @@ func TestParse_UpdatedSubscriptionNotification(t *testing.T) {
 	} else if n, ok := result.(*webhooks.UpdatedSubscriptionNotification); !ok {
 		t.Fatalf("unexpected type: %T, result")
 	} else if !reflect.DeepEqual(n, &webhooks.UpdatedSubscriptionNotification{
-		Account: recurly.Account{
+		Account: webhooks.Account{
 			XMLName:   xml.Name{Local: "account"},
 			Code:      "1",
 			Email:     "verena@example.com",
@@ -115,7 +115,7 @@ func TestParse_RenewedSubscriptionNotification(t *testing.T) {
 	} else if n, ok := result.(*webhooks.RenewedSubscriptionNotification); !ok {
 		t.Fatalf("unexpected type: %T, result")
 	} else if !reflect.DeepEqual(n, &webhooks.RenewedSubscriptionNotification{
-		Account: recurly.Account{
+		Account: webhooks.Account{
 			XMLName:     xml.Name{Local: "account"},
 			Code:        "1",
 			Email:       "verena@example.com",
@@ -156,7 +156,7 @@ func TestParse_ExpiredSubscriptionNotification(t *testing.T) {
 	} else if n, ok := result.(*webhooks.ExpiredSubscriptionNotification); !ok {
 		t.Fatalf("unexpected type: %T, result")
 	} else if !reflect.DeepEqual(n, &webhooks.ExpiredSubscriptionNotification{
-		Account: recurly.Account{
+		Account: webhooks.Account{
 			XMLName:   xml.Name{Local: "account"},
 			Code:      "1",
 			Email:     "verena@example.com",
@@ -198,7 +198,7 @@ func TestParse_CanceledSubscriptionNotification(t *testing.T) {
 	} else if n, ok := result.(*webhooks.CanceledSubscriptionNotification); !ok {
 		t.Fatalf("unexpected type: %T, result")
 	} else if !reflect.DeepEqual(n, &webhooks.CanceledSubscriptionNotification{
-		Account: recurly.Account{
+		Account: webhooks.Account{
 			XMLName:   xml.Name{Local: "account"},
 			Code:      "1",
 			Email:     "verena@example.com",
@@ -234,7 +234,7 @@ func TestParse_NewInvoiceNotification(t *testing.T) {
 	} else if n, ok := result.(*webhooks.NewInvoiceNotification); !ok {
 		t.Fatalf("unexpected type: %T, result")
 	} else if !reflect.DeepEqual(n, &webhooks.NewInvoiceNotification{
-		Account: recurly.Account{
+		Account: webhooks.Account{
 			XMLName:   xml.Name{Local: "account"},
 			Code:      "1",
 			Email:     "verena@example.com",
@@ -264,7 +264,7 @@ func TestParse_PastDueInvoiceNotification(t *testing.T) {
 	} else if n, ok := result.(*webhooks.PastDueInvoiceNotification); !ok {
 		t.Fatalf("unexpected type: %T, result")
 	} else if !reflect.DeepEqual(n, &webhooks.PastDueInvoiceNotification{
-		Account: recurly.Account{
+		Account: webhooks.Account{
 			XMLName:     xml.Name{Local: "account"},
 			Code:        "1",
 			Username:    "verena",


### PR DESCRIPTION
Recurly sends a reduced version of the account struct with webhooks. This PR updates the notification structs to use that instead of the standard Recurly Account struct. Users may need to update the type of struct, but should not have to update the contents in implementations. 