### PR TITLE
Sanitize incoming UUID parameters

### DIFF
--- a/adjustments_service.go
+++ b/adjustments_service.go
@@ -40,7 +40,7 @@ func (s *adjustmentsImpl) List(accountCode string, params Params) (*Response, []
 // Get returns information about a single adjustment.
 // https://docs.recurly.com/api/adjustments#get-adjustments
 func (s *adjustmentsImpl) Get(uuid string) (*Response, *Adjustment, error) {
-	action := fmt.Sprintf("adjustments/%s", uuid)
+	action := fmt.Sprintf("adjustments/%s", SanitizeUUID(uuid))
 	req, err := s.client.newRequest("GET", action, nil, nil)
 	if err != nil {
 		return nil, nil, err
@@ -77,7 +77,7 @@ func (s *adjustmentsImpl) Create(accountCode string, a Adjustment) (*Response, *
 // Delete removes a non-invoiced adjustment from an account.
 // https://docs.recurly.com/api/adjustments#delete-adjustment
 func (s *adjustmentsImpl) Delete(uuid string) (*Response, error) {
-	action := fmt.Sprintf("adjustments/%s", uuid)
+	action := fmt.Sprintf("adjustments/%s", SanitizeUUID(uuid))
 	req, err := s.client.newRequest("DELETE", action, nil, nil)
 	if err != nil {
 		return nil, err

--- a/adjustments_test.go
+++ b/adjustments_test.go
@@ -181,7 +181,7 @@ func TestAdjustments_Get(t *testing.T) {
 			</adjustment>`)
 	})
 
-	resp, adjustment, err := client.Adjustments.Get("626db120a84102b1809909071c701c60")
+	resp, adjustment, err := client.Adjustments.Get("626db12-0a84102b180990-9071c701c60") // UUID has dashes
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	} else if resp.IsError() {
@@ -192,7 +192,7 @@ func TestAdjustments_Get(t *testing.T) {
 	if !reflect.DeepEqual(adjustment, &recurly.Adjustment{
 		AccountCode:            "100",
 		InvoiceNumber:          1108,
-		UUID:                   "626db120a84102b1809909071c701c60",
+		UUID:                   "626db120a84102b1809909071c701c60", // UUID has been sanitizzed
 		State:                  "invoiced",
 		Description:            "One-time Charged Fee",
 		ProductCode:            "basic",
@@ -327,7 +327,7 @@ func TestAdjustments_Delete(t *testing.T) {
 		w.WriteHeader(204)
 	})
 
-	resp, err := client.Adjustments.Delete("945a4cb9afd64300b97b138407a51aef")
+	resp, err := client.Adjustments.Delete("945a4cb9afd-64300b97b1384-07a51aef") // UUID has dashes and should be sanitized
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	} else if resp.StatusCode != 204 {

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -1,6 +1,14 @@
 package recurly
 
-import "encoding/xml"
+import (
+	"encoding/xml"
+	"strings"
+)
+
+// SanitizeUUID returns the uuid without dashes.
+func SanitizeUUID(id string) string {
+	return strings.TrimSpace(strings.Replace(id, "-", "", -1))
+}
 
 const (
 	// SubscriptionStateActive represents subscriptions that are valid for the

--- a/subscriptions_service.go
+++ b/subscriptions_service.go
@@ -58,7 +58,7 @@ func (s *subscriptionsImpl) ListAccount(accountCode string, params Params) (*Res
 // Get returns a subscription by uuid
 // https://docs.recurly.com/api/subscriptions#lookup-subscription
 func (s *subscriptionsImpl) Get(uuid string) (*Response, *Subscription, error) {
-	action := fmt.Sprintf("subscriptions/%s", uuid)
+	action := fmt.Sprintf("subscriptions/%s", SanitizeUUID(uuid))
 	req, err := s.client.newRequest("GET", action, nil, nil)
 	if err != nil {
 		return nil, nil, err
@@ -108,7 +108,7 @@ func (s *subscriptionsImpl) Preview(sub NewSubscription) (*Response, *Subscripti
 // value. See recurly documentation for more info.
 // https://docs.recurly.com/api/subscriptions#update-subscription
 func (s *subscriptionsImpl) Update(uuid string, sub UpdateSubscription) (*Response, *Subscription, error) {
-	action := fmt.Sprintf("subscriptions/%s", uuid)
+	action := fmt.Sprintf("subscriptions/%s", SanitizeUUID(uuid))
 	req, err := s.client.newRequest("PUT", action, nil, sub)
 	if err != nil {
 		return nil, nil, err
@@ -124,7 +124,7 @@ func (s *subscriptionsImpl) Update(uuid string, sub UpdateSubscription) (*Respon
 // Updating notes will not trigger the renewal.
 // https://docs.recurly.com/api/subscriptions#update-subscription-notes
 func (s *subscriptionsImpl) UpdateNotes(uuid string, n SubscriptionNotes) (*Response, *Subscription, error) {
-	action := fmt.Sprintf("subscriptions/%s/notes", uuid)
+	action := fmt.Sprintf("subscriptions/%s/notes", SanitizeUUID(uuid))
 	req, err := s.client.newRequest("PUT", action, nil, n)
 	if err != nil {
 		return nil, nil, err
@@ -140,7 +140,7 @@ func (s *subscriptionsImpl) UpdateNotes(uuid string, n SubscriptionNotes) (*Resp
 // account without committing a subscription change or posting an invoice.
 // https://docs.recurly.com/api/subscriptions#sub-change-preview
 func (s *subscriptionsImpl) PreviewChange(uuid string, sub UpdateSubscription) (*Response, *Subscription, error) {
-	action := fmt.Sprintf("subscriptions/%s/preview", uuid)
+	action := fmt.Sprintf("subscriptions/%s/preview", SanitizeUUID(uuid))
 	req, err := s.client.newRequest("POST", action, nil, sub)
 	if err != nil {
 		return nil, nil, err
@@ -156,7 +156,7 @@ func (s *subscriptionsImpl) PreviewChange(uuid string, sub UpdateSubscription) (
 // end of the current bill cycle.
 // https://docs.recurly.com/api/subscriptions#cancel-subscription
 func (s *subscriptionsImpl) Cancel(uuid string) (*Response, *Subscription, error) {
-	action := fmt.Sprintf("subscriptions/%s/cancel", uuid)
+	action := fmt.Sprintf("subscriptions/%s/cancel", SanitizeUUID(uuid))
 	req, err := s.client.newRequest("PUT", action, nil, nil)
 	if err != nil {
 		return nil, nil, err
@@ -172,7 +172,7 @@ func (s *subscriptionsImpl) Cancel(uuid string) (*Response, *Subscription, error
 // of the current bill cycle.
 // https://docs.recurly.com/api/subscriptions#reactivate-subscription
 func (s *subscriptionsImpl) Reactivate(uuid string) (*Response, *Subscription, error) {
-	action := fmt.Sprintf("subscriptions/%s/reactivate", uuid)
+	action := fmt.Sprintf("subscriptions/%s/reactivate", SanitizeUUID(uuid))
 	req, err := s.client.newRequest("PUT", action, nil, nil)
 	if err != nil {
 		return nil, nil, err
@@ -188,7 +188,7 @@ func (s *subscriptionsImpl) Reactivate(uuid string) (*Response, *Subscription, e
 // immediately with a full refund.
 // https://docs.recurly.com/api/subscriptions#terminate-subscription
 func (s *subscriptionsImpl) TerminateWithPartialRefund(uuid string) (*Response, *Subscription, error) {
-	action := fmt.Sprintf("subscriptions/%s/terminate", uuid)
+	action := fmt.Sprintf("subscriptions/%s/terminate", SanitizeUUID(uuid))
 	req, err := s.client.newRequest("PUT", action, Params{"refund_type": "partial"}, nil)
 	if err != nil {
 		return nil, nil, err
@@ -204,7 +204,7 @@ func (s *subscriptionsImpl) TerminateWithPartialRefund(uuid string) (*Response, 
 // immediately with a full refund.
 // https://docs.recurly.com/api/subscriptions#terminate-subscription
 func (s *subscriptionsImpl) TerminateWithFullRefund(uuid string) (*Response, *Subscription, error) {
-	action := fmt.Sprintf("subscriptions/%s/terminate", uuid)
+	action := fmt.Sprintf("subscriptions/%s/terminate", SanitizeUUID(uuid))
 	req, err := s.client.newRequest("PUT", action, Params{"refund_type": "full"}, nil)
 	if err != nil {
 		return nil, nil, err
@@ -220,7 +220,7 @@ func (s *subscriptionsImpl) TerminateWithFullRefund(uuid string) (*Response, *Su
 // immediately with no refund.
 // https://docs.recurly.com/api/subscriptions#terminate-subscription
 func (s *subscriptionsImpl) TerminateWithoutRefund(uuid string) (*Response, *Subscription, error) {
-	action := fmt.Sprintf("subscriptions/%s/terminate", uuid)
+	action := fmt.Sprintf("subscriptions/%s/terminate", SanitizeUUID(uuid))
 	req, err := s.client.newRequest("PUT", action, Params{"refund_type": "none"}, nil)
 	if err != nil {
 		return nil, nil, err
@@ -237,7 +237,7 @@ func (s *subscriptionsImpl) TerminateWithoutRefund(uuid string) (*Response, *Sub
 // modifying the renewal date will modify when the trial expires.
 // https://docs.recurly.com/api/subscriptions#postpone-subscription
 func (s *subscriptionsImpl) Postpone(uuid string, dt time.Time, bulk bool) (*Response, *Subscription, error) {
-	action := fmt.Sprintf("subscriptions/%s/postpone", uuid)
+	action := fmt.Sprintf("subscriptions/%s/postpone", SanitizeUUID(uuid))
 	req, err := s.client.newRequest("PUT", action, Params{
 		"bulk":              bulk,
 		"next_renewal_date": dt.Format(time.RFC3339),

--- a/subscriptions_test.go
+++ b/subscriptions_test.go
@@ -556,7 +556,7 @@ func TestSubscriptions_Get(t *testing.T) {
 		</subscription>`)
 	})
 
-	r, subscription, err := client.Subscriptions.Get("44f83d7cba354d5b84812419f923ea96")
+	r, subscription, err := client.Subscriptions.Get("44f83d7cb-a354d5b848-12419f923ea96") // UUID has dashes
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	} else if r.IsError() {
@@ -571,7 +571,7 @@ func TestSubscriptions_Get(t *testing.T) {
 		},
 		AccountCode:            "1",
 		InvoiceNumber:          1108,
-		UUID:                   "44f83d7cba354d5b84812419f923ea96",
+		UUID:                   "44f83d7cba354d5b84812419f923ea96", // UUID has been sanitized
 		State:                  "active",
 		UnitAmountInCents:      800,
 		Currency:               "EUR",
@@ -816,7 +816,7 @@ func TestSubscriptions_Update(t *testing.T) {
 		fmt.Fprint(w, `<?xml version="1.0" encoding="UTF-8"?><subscription></subscription>`)
 	})
 
-	r, _, err := client.Subscriptions.Update("44f83d7cba354d5b84812419f923ea96", recurly.UpdateSubscription{})
+	r, _, err := client.Subscriptions.Update("44f83d7cba-354d5b84812419-f923ea96", recurly.UpdateSubscription{}) // UUID has dashes and should be sanitized
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	} else if r.IsError() {
@@ -836,7 +836,7 @@ func TestSubscriptions_Notes(t *testing.T) {
 		fmt.Fprint(w, `<?xml version="1.0" encoding="UTF-8"?><subscription></subscription>`)
 	})
 
-	r, _, err := client.Subscriptions.UpdateNotes("44f83d7cba354d5b84812419f923ea96", recurly.SubscriptionNotes{})
+	r, _, err := client.Subscriptions.UpdateNotes("44f83d7cba354d5-b8481241-9f923ea96", recurly.SubscriptionNotes{}) // UUID has dashes and should be sanitized
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	} else if r.IsError() {
@@ -856,7 +856,7 @@ func TestSubscriptions_Change(t *testing.T) {
 		fmt.Fprint(w, `<?xml version="1.0" encoding="UTF-8"?><subscription></subscription>`)
 	})
 
-	r, _, err := client.Subscriptions.PreviewChange("44f83d7cba354d5b84812419f923ea96", recurly.UpdateSubscription{})
+	r, _, err := client.Subscriptions.PreviewChange("44f83d7cba-354d5b84812-419f923ea96", recurly.UpdateSubscription{}) // UUID has dashes and should be sanitized
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	} else if r.IsError() {
@@ -876,7 +876,7 @@ func TestSubscriptions_Cancel(t *testing.T) {
 		fmt.Fprint(w, `<?xml version="1.0" encoding="UTF-8"?><subscription></subscription>`)
 	})
 
-	r, _, err := client.Subscriptions.Cancel("44f83d7cba354d5b84812419f923ea96")
+	r, _, err := client.Subscriptions.Cancel("44f83d7cba-354d5b848124-19f923ea96") // UUID has dashes and should be sanitized
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	} else if r.IsError() {
@@ -896,7 +896,7 @@ func TestSubscriptions_Reactivate(t *testing.T) {
 		fmt.Fprint(w, `<?xml version="1.0" encoding="UTF-8"?><subscription></subscription>`)
 	})
 
-	r, _, err := client.Subscriptions.Reactivate("44f83d7cba354d5b84812419f923ea96")
+	r, _, err := client.Subscriptions.Reactivate("44f83d7cba35-4d5b8481241-9f923ea96") // UUID has dashes and should be sanitized
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	} else if r.IsError() {
@@ -918,7 +918,7 @@ func TestSubscriptions_Terminate_PartialRefund(t *testing.T) {
 		fmt.Fprint(w, `<?xml version="1.0" encoding="UTF-8"?><subscription></subscription>`)
 	})
 
-	r, _, err := client.Subscriptions.TerminateWithPartialRefund("44f83d7cba354d5b84812419f923ea96")
+	r, _, err := client.Subscriptions.TerminateWithPartialRefund("44f83d7c-ba354d5b84812419f923ea96") // UUID has dashes and should be sanitized
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	} else if r.IsError() {
@@ -940,7 +940,7 @@ func TestSubscriptions_Terminate_FullRefund(t *testing.T) {
 		fmt.Fprint(w, `<?xml version="1.0" encoding="UTF-8"?><subscription></subscription>`)
 	})
 
-	r, _, err := client.Subscriptions.TerminateWithFullRefund("44f83d7cba354d5b84812419f923ea96")
+	r, _, err := client.Subscriptions.TerminateWithFullRefund("44f83d7cba354d5b84-812419f923ea96") // UUID has dashes and should be sanitized
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	} else if r.IsError() {
@@ -962,7 +962,7 @@ func TestSubscriptions_Terminate_WithoutRefund(t *testing.T) {
 		fmt.Fprint(w, `<?xml version="1.0" encoding="UTF-8"?><subscription></subscription>`)
 	})
 
-	r, _, err := client.Subscriptions.TerminateWithoutRefund("44f83d7cba354d5b84812419f923ea96")
+	r, _, err := client.Subscriptions.TerminateWithoutRefund("44f83d7c-ba354d5b84812419f923ea96") // UUID has dashes and should be sanitized
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	} else if r.IsError() {
@@ -987,7 +987,7 @@ func TestSubscriptions_Postpone(t *testing.T) {
 		fmt.Fprint(w, `<?xml version="1.0" encoding="UTF-8"?><subscription></subscription>`)
 	})
 
-	r, _, err := client.Subscriptions.Postpone("44f83d7cba354d5b84812419f923ea96", ts, false)
+	r, _, err := client.Subscriptions.Postpone("44f83d7cba354d5b8481-2419f923ea96", ts, false) // UUID has dashes and should be sanitized
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	} else if r.IsError() {

--- a/transactions_service.go
+++ b/transactions_service.go
@@ -60,7 +60,7 @@ func (s *transactionsImpl) ListAccount(accountCode string, params Params) (*Resp
 // Please see transaction error codes for more details.
 // https://dev.recurly.com/docs/lookup-transaction
 func (s *transactionsImpl) Get(uuid string) (*Response, *Transaction, error) {
-	action := fmt.Sprintf("transactions/%s", uuid)
+	action := fmt.Sprintf("transactions/%s", SanitizeUUID(uuid))
 	req, err := s.client.newRequest("GET", action, nil, nil)
 	if err != nil {
 		return nil, nil, err

--- a/transactions_test.go
+++ b/transactions_test.go
@@ -358,7 +358,7 @@ func TestTransactions_Get(t *testing.T) {
     	</transaction>`)
 	})
 
-	r, transaction, err := client.Transactions.Get("a13acd8fe4294916b79aec87b7ea441f")
+	r, transaction, err := client.Transactions.Get("a13acd8f-e4294916b79aec87-b7ea441f") // UUID contains dashes
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	} else if r.IsError() {
@@ -368,7 +368,7 @@ func TestTransactions_Get(t *testing.T) {
 	if !reflect.DeepEqual(transaction, &recurly.Transaction{
 		InvoiceNumber:    1108,
 		SubscriptionUUID: "17caaca1716f33572edc8146e0aaefde",
-		UUID:             "a13acd8fe4294916b79aec87b7ea441f",
+		UUID:             "a13acd8fe4294916b79aec87b7ea441f", // UUID has been sanitized
 		Action:           "purchase",
 		AmountInCents:    1000,
 		TaxInCents:       0,


### PR DESCRIPTION
Recurly will not match uuids with dashes, i.e. `44f83d7cba-354d5b8481-2419f9-23ea96` will not equal `44f83d7cba354d5b84812419f923ea96`. This PR ensures that incoming UUID parameters, which may have been formatted with dashes, are sanitized in `Adjustments`, `Subscriptions`, and `Transactions`. Includes tests. 