### PR TITLE
Add webhooks-specific invoice struct

### DIFF
--- a/webhooks/testdata/past_due_invoice_notification.xml
+++ b/webhooks/testdata/past_due_invoice_notification.xml
@@ -16,6 +16,6 @@
     <po_number></po_number>
     <vat_number></vat_number>
     <total_in_cents type="integer">1100</total_in_cents>
-    <date type="datetime">2014-01-01T20:20:29Z</date>
+    <date type="datetime">2014-01-01T20:21:44Z</date>
   </invoice>
 </past_due_invoice_notification>

--- a/webhooks/webhooks.go
+++ b/webhooks/webhooks.go
@@ -64,6 +64,24 @@ type Transaction struct {
 	Refundable        recurly.NullBool `xml:"refundable,omitempty"`
 }
 
+// Invoice represents the invoice object sent in webhooks.
+type Invoice struct {
+	XMLName             xml.Name         `xml:"invoice,omitempty"`
+	SubscriptionUUID    string           `xml:"subscription_id,omitempty"`
+	UUID                string           `xml:"uuid,omitempty"`
+	State               string           `xml:"state,omitempty"`
+	InvoiceNumberPrefix string           `xml:"invoice_number_prefix,omitempty"`
+	InvoiceNumber       int              `xml:"invoice_number,omitempty"`
+	PONumber            string           `xml:"po_number,omitempty"`
+	VATNumber           string           `xml:"vat_number,omitempty"`
+	TotalInCents        int              `xml:"total_in_cents,omitempty"`
+	Currency            string           `xml:"currency,omitempty"`
+	CreatedAt           recurly.NullTime `xml:"date,omitempty"`
+	ClosedAt            recurly.NullTime `xml:"closed_at,omitempty"`
+	NetTerms            recurly.NullInt  `xml:"net_terms,omitempty"`
+	CollectionMethod    string           `xml:"collection_method,omitempty"`
+}
+
 // Transaction constants.
 const (
 	TransactionFailureTypeDeclined  = "declined"
@@ -113,15 +131,15 @@ type (
 	// NewInvoiceNotification is sent when an invoice generated.
 	// https://dev.recurly.com/page/webhooks#section-new-invoice
 	NewInvoiceNotification struct {
-		Account Account         `xml:"account"`
-		Invoice recurly.Invoice `xml:"invoice"`
+		Account Account `xml:"account"`
+		Invoice Invoice `xml:"invoice"`
 	}
 
 	// PastDueInvoiceNotification is sent when an invoice is past due.
 	// https://dev.recurly.com/v2.4/page/webhooks#section-past-due-invoice
 	PastDueInvoiceNotification struct {
-		Account Account         `xml:"account"`
-		Invoice recurly.Invoice `xml:"invoice"`
+		Account Account `xml:"account"`
+		Invoice Invoice `xml:"invoice"`
 	}
 )
 

--- a/webhooks/webhooks_test.go
+++ b/webhooks/webhooks_test.go
@@ -228,6 +228,7 @@ func TestParse_CanceledSubscriptionNotification(t *testing.T) {
 
 func TestParse_NewInvoiceNotification(t *testing.T) {
 	xmlFile := MustOpenFile("testdata/new_invoice_notification.xml")
+	createdAt := time.Date(2014, 1, 1, 20, 21, 44, 0, time.UTC)
 	result, err := webhooks.Parse(xmlFile)
 	if err != nil {
 		t.Fatal(err)
@@ -241,11 +242,12 @@ func TestParse_NewInvoiceNotification(t *testing.T) {
 			FirstName: "Verena",
 			LastName:  "Example",
 		},
-		Invoice: recurly.Invoice{
+		Invoice: webhooks.Invoice{
 			XMLName:          xml.Name{Local: "invoice"},
 			UUID:             "ffc64d71d4b5404e93f13aac9c63b007",
 			State:            "open",
 			Currency:         "USD",
+			CreatedAt:        recurly.NullTime{Time: &createdAt},
 			InvoiceNumber:    1000,
 			TotalInCents:     1000,
 			NetTerms:         recurly.NullInt{Valid: true, Int: 0},
@@ -258,6 +260,7 @@ func TestParse_NewInvoiceNotification(t *testing.T) {
 
 func TestParse_PastDueInvoiceNotification(t *testing.T) {
 	xmlFile := MustOpenFile("testdata/past_due_invoice_notification.xml")
+	createdAt := time.Date(2014, 1, 1, 20, 21, 44, 0, time.UTC)
 	result, err := webhooks.Parse(xmlFile)
 	if err != nil {
 		t.Fatal(err)
@@ -273,10 +276,11 @@ func TestParse_PastDueInvoiceNotification(t *testing.T) {
 			LastName:    "Example",
 			CompanyName: "Company, Inc.",
 		},
-		Invoice: recurly.Invoice{
+		Invoice: webhooks.Invoice{
 			XMLName:       xml.Name{Local: "invoice"},
 			UUID:          "ffc64d71d4b5404e93f13aac9c63b007",
 			State:         "past_due",
+			CreatedAt:     recurly.NullTime{Time: &createdAt},
 			InvoiceNumber: 1000,
 			TotalInCents:  1100,
 		},


### PR DESCRIPTION
Webhook invoice objects are reduced versions of standard Recurly objects. To avoid confusion, the webhooks package contains some package-specific structs for those objects. This PR adds the `webhooks.Invoice` struct. 