### PR TITLE
Add TransactionError to Transaction struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ if resp.StatusCode == 422 {
     // ...
 }
 ```
+recurly.Response embeds a Transaction when present. 
 
 ## Usage
 The basic usage format is to create a client, and then operate directly off of each

--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ if resp.StatusCode == 422 {
     // ...
 }
 ```
-recurly.Response embeds a Transaction when present. 
 
 ## Usage
 The basic usage format is to create a client, and then operate directly off of each

--- a/client.go
+++ b/client.go
@@ -136,7 +136,7 @@ func (c *Client) do(req *http.Request, v interface{}) (*Response, error) {
 			// If the response object includes a TransactionError, set the
 			// transaction field on the response object and the TransactionError field.
 			if ve.Transaction != nil {
-				response.Transaction = ve.Transaction
+				response.transaction = ve.Transaction
 
 			}
 		} else if response.IsClientError() { // Parse possible individual error message

--- a/client.go
+++ b/client.go
@@ -122,10 +122,9 @@ func (c *Client) do(req *http.Request, v interface{}) (*Response, error) {
 	if response.IsError() { // Parse validation errors
 		if response.StatusCode == http.StatusUnprocessableEntity {
 			var ve struct {
-				XMLName          xml.Name          `xml:"errors"`
-				Errors           []Error           `xml:"error"`
-				Transaction      *Transaction      `xml:"transaction,omitempty"`
-				TransactionError *TransactionError `xml:"transaction_error,omitempty"`
+				XMLName     xml.Name     `xml:"errors"`
+				Errors      []Error      `xml:"error"`
+				Transaction *Transaction `xml:"transaction,omitempty"`
 			}
 
 			if err = decoder.Decode(&ve); err != nil {
@@ -136,8 +135,8 @@ func (c *Client) do(req *http.Request, v interface{}) (*Response, error) {
 
 			// If the response object includes a TransactionError, set the
 			// transaction field on the response object and the TransactionError field.
-			if ve.TransactionError != nil {
-				response.transaction = &Transaction{TransactionError: ve.TransactionError}
+			if ve.Transaction != nil {
+				response.Transaction = ve.Transaction
 
 			}
 		} else if response.IsClientError() { // Parse possible individual error message

--- a/client.go
+++ b/client.go
@@ -133,8 +133,13 @@ func (c *Client) do(req *http.Request, v interface{}) (*Response, error) {
 			}
 
 			response.Errors = ve.Errors
-			response.Transaction = ve.Transaction
-			response.TransactionError = ve.TransactionError
+
+			// If the response object includes a TransactionError, set the
+			// transaction field on the response object and the TransactionError field.
+			if ve.TransactionError != nil {
+				response.transaction = &Transaction{TransactionError: ve.TransactionError}
+
+			}
 		} else if response.IsClientError() { // Parse possible individual error message
 			var ve struct {
 				XMLName     xml.Name `xml:"error"`

--- a/client.go
+++ b/client.go
@@ -137,7 +137,6 @@ func (c *Client) do(req *http.Request, v interface{}) (*Response, error) {
 			// transaction field on the response object and the TransactionError field.
 			if ve.Transaction != nil {
 				response.transaction = ve.Transaction
-
 			}
 		} else if response.IsClientError() { // Parse possible individual error message
 			var ve struct {

--- a/client_internal_test.go
+++ b/client_internal_test.go
@@ -100,7 +100,7 @@ func TestClient_Error(t *testing.T) {
 	}
 
 	// Transaction should be nil
-	if resp.transaction != nil {
+	if resp.Transaction != nil {
 		t.Fatal("expected transaction to be nil")
 	}
 

--- a/client_internal_test.go
+++ b/client_internal_test.go
@@ -99,10 +99,8 @@ func TestClient_Error(t *testing.T) {
 		t.Fatalf("expected response to not be ok")
 	}
 
-	// TransactionError should be nil
-	if resp.TransactionError != nil {
-		t.Fatal("expected transaction error to be nil")
-	} else if resp.Transaction != nil {
+	// Transaction should be nil
+	if resp.transaction != nil {
 		t.Fatal("expected transaction to be nil")
 	}
 

--- a/client_internal_test.go
+++ b/client_internal_test.go
@@ -100,7 +100,7 @@ func TestClient_Error(t *testing.T) {
 	}
 
 	// Transaction should be nil
-	if resp.Transaction != nil {
+	if resp.transaction != nil {
 		t.Fatal("expected transaction to be nil")
 	}
 

--- a/invoices_test.go
+++ b/invoices_test.go
@@ -354,7 +354,7 @@ func TestInvoices_Get(t *testing.T) {
                     <amount_in_cents type="integer">1000</amount_in_cents>
                     <tax_in_cents type="integer">0</tax_in_cents>
                     <currency>USD</currency>
-                    <status>success</status>
+                    <status>declined</status>
                     <payment_method>credit_card</payment_method>
                     <reference>5416477</reference>
                     <source>subscription</source>
@@ -363,6 +363,13 @@ func TestInvoices_Get(t *testing.T) {
                     <voidable type="boolean">true</voidable>
                     <refundable type="boolean">true</refundable>
                     <ip_address>127.0.0.1</ip_address>
+					<transaction_error>
+						<error_code>declined</error_code>
+						<error_category>soft</error_category>
+						<merchant_message>The customer's bank has declined their card. The customer will need to contact their bank to learn the cause.</merchant_message>
+						<customer_message>Your transaction was declined. Please use a different card or contact your bank.</customer_message>
+						<gateway_error_code>2</gateway_error_code>
+					</transaction_error>
                     <cvv_result code="M">Match</cvv_result>
                     <avs_result code="D">Street address and postal code match.</avs_result>
                     <avs_result_street nil="nil"/>
@@ -462,7 +469,7 @@ func TestInvoices_Get(t *testing.T) {
 				AmountInCents:    1000,
 				TaxInCents:       0,
 				Currency:         "USD",
-				Status:           "success",
+				Status:           "declined",
 				PaymentMethod:    "credit_card",
 				Reference:        "5416477",
 				Source:           "subscription",
@@ -471,6 +478,14 @@ func TestInvoices_Get(t *testing.T) {
 				Voidable:         recurly.NewBool(true),
 				Refundable:       recurly.NewBool(true),
 				IPAddress:        net.ParseIP("127.0.0.1"),
+				TransactionError: recurly.TransactionError{
+					XMLName:          xml.Name{Local: "transaction_error"},
+					ErrorCode:        "declined",
+					ErrorCategory:    "soft",
+					MerchantMessage:  "The customer's bank has declined their card. The customer will need to contact their bank to learn the cause.",
+					CustomerMessage:  "Your transaction was declined. Please use a different card or contact your bank.",
+					GatewayErrorCode: "2",
+				},
 				CVVResult: recurly.CVVResult{
 					recurly.TransactionResult{
 						Code:    "M",

--- a/invoices_test.go
+++ b/invoices_test.go
@@ -478,7 +478,7 @@ func TestInvoices_Get(t *testing.T) {
 				Voidable:         recurly.NewBool(true),
 				Refundable:       recurly.NewBool(true),
 				IPAddress:        net.ParseIP("127.0.0.1"),
-				TransactionError: recurly.TransactionError{
+				TransactionError: &recurly.TransactionError{
 					XMLName:          xml.Name{Local: "transaction_error"},
 					ErrorCode:        "declined",
 					ErrorCategory:    "soft",

--- a/invoices_test.go
+++ b/invoices_test.go
@@ -363,13 +363,13 @@ func TestInvoices_Get(t *testing.T) {
                     <voidable type="boolean">true</voidable>
                     <refundable type="boolean">true</refundable>
                     <ip_address>127.0.0.1</ip_address>
-					<transaction_error>
-						<error_code>declined</error_code>
-						<error_category>soft</error_category>
-						<merchant_message>The customer's bank has declined their card. The customer will need to contact their bank to learn the cause.</merchant_message>
-						<customer_message>Your transaction was declined. Please use a different card or contact your bank.</customer_message>
-						<gateway_error_code>2</gateway_error_code>
-					</transaction_error>
+                    <transaction_error>
+                    	<error_code>declined</error_code>
+                    	<error_category>soft</error_category>
+                    	<merchant_message>The customer's bank has declined their card. The customer will need to contact their bank to learn the cause.</merchant_message>
+                    	<customer_message>Your transaction was declined. Please use a different card or contact your bank.</customer_message>
+                    	<gateway_error_code>2</gateway_error_code>
+                    </transaction_error>
                     <cvv_result code="M">Match</cvv_result>
                     <avs_result code="D">Street address and postal code match.</avs_result>
                     <avs_result_street nil="nil"/>

--- a/mock/services.go
+++ b/mock/services.go
@@ -471,7 +471,7 @@ type SubscriptionsService struct {
 	OnGet      func(uuid string) (*recurly.Response, *recurly.Subscription, error)
 	GetInvoked bool
 
-	OnCreate      func(sub recurly.NewSubscription) (*recurly.Response, *recurly.Subscription, error)
+	OnCreate      func(sub recurly.NewSubscription) (*recurly.Response, *recurly.NewSubscriptionResponse, error)
 	CreateInvoked bool
 
 	OnPreview      func(sub recurly.NewSubscription) (*recurly.Response, *recurly.Subscription, error)
@@ -520,7 +520,7 @@ func (m *SubscriptionsService) Get(uuid string) (*recurly.Response, *recurly.Sub
 	return m.OnGet(uuid)
 }
 
-func (m *SubscriptionsService) Create(sub recurly.NewSubscription) (*recurly.Response, *recurly.Subscription, error) {
+func (m *SubscriptionsService) Create(sub recurly.NewSubscription) (*recurly.Response, *recurly.NewSubscriptionResponse, error) {
 	m.CreateInvoked = true
 	return m.OnCreate(sub)
 }

--- a/responses.go
+++ b/responses.go
@@ -15,15 +15,9 @@ type Response struct {
 	// Errors holds an array of validation errors if any occurred.
 	Errors []Error
 
-	// Transaction holds the transaction returned with a transaction error.
+	// transaction holds the transaction returned with a transaction error.
 	// This will be populated when creating a new subscription if the payment fails.
-	Transaction *Transaction
-
-	// TransactionError holds transaction errors from your payment gateway.
-	// This will only be populated when creating a new subscription,
-	// updating billing information, and processing a one-time transaction.
-	// https://recurly.readme.io/v2.0/page/transaction-errors
-	TransactionError *TransactionError
+	transaction *Transaction
 }
 
 var (

--- a/responses.go
+++ b/responses.go
@@ -15,9 +15,8 @@ type Response struct {
 	// Errors holds an array of validation errors if any occurred.
 	Errors []Error
 
-	// Transaction holds the transaction returned with a transaction error.
-	// This will be populated when creating a new subscription if the payment fails.
-	Transaction *Transaction
+	// transaction holds the transaction returned with a transaction error.
+	transaction *Transaction
 }
 
 var (

--- a/responses.go
+++ b/responses.go
@@ -15,9 +15,9 @@ type Response struct {
 	// Errors holds an array of validation errors if any occurred.
 	Errors []Error
 
-	// transaction holds the transaction returned with a transaction error.
+	// Transaction holds the transaction returned with a transaction error.
 	// This will be populated when creating a new subscription if the payment fails.
-	transaction *Transaction
+	Transaction *Transaction
 }
 
 var (

--- a/responses.go
+++ b/responses.go
@@ -107,15 +107,3 @@ type Error struct {
 	Field   string   `xml:"field,attr"`
 	Symbol  string   `xml:"symbol,attr"`
 }
-
-// TransactionError is an error encounted from your payment gateway that
-// recurly has standardized.
-// https://recurly.readme.io/v2.0/page/transaction-errors
-type TransactionError struct {
-	XMLName          xml.Name `xml:"transaction_error"`
-	ErrorCode        string   `xml:"error_code,omitempty"`
-	ErrorCategory    string   `xml:"error_category,omitempty"`
-	MerchantMessage  string   `xml:"merchant_message,omitempty"`
-	CustomerMessage  string   `xml:"customer_message,omitempty"`
-	GatewayErrorCode string   `xml:"gateway_error_code,omitempty"`
-}

--- a/services.go
+++ b/services.go
@@ -92,7 +92,7 @@ type SubscriptionsService interface {
 	List(params Params) (*Response, []Subscription, error)
 	ListAccount(accountCode string, params Params) (*Response, []Subscription, error)
 	Get(uuid string) (*Response, *Subscription, error)
-	Create(sub NewSubscription) (*Response, *Subscription, error)
+	Create(sub NewSubscription) (*Response, *NewSubscriptionResponse, error)
 	Preview(sub NewSubscription) (*Response, *Subscription, error)
 	Update(uuid string, sub UpdateSubscription) (*Response, *Subscription, error)
 	UpdateNotes(uuid string, n SubscriptionNotes) (*Response, *Subscription, error)

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -192,6 +192,12 @@ type NewSubscription struct {
 	BankAccountAuthorizedAt NullTime             `xml:"bank_account_authorized_at,omitempty"`
 }
 
+// NewSubscriptionResponse is used to unmarshal either the subscription or the transaction.
+type NewSubscriptionResponse struct {
+	Subscription *Subscription `xml:"subscription,omitempty"`
+	Transaction  *Transaction  `xml:"errors>transaction,omitempty"` // UnprocessableEntity errors return only the transaction
+}
+
 // UpdateSubscription is used to update subscriptions
 type UpdateSubscription struct {
 	XMLName            xml.Name             `xml:"subscription"`

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -194,8 +194,8 @@ type NewSubscription struct {
 
 // NewSubscriptionResponse is used to unmarshal either the subscription or the transaction.
 type NewSubscriptionResponse struct {
-	Subscription *Subscription `xml:"subscription,omitempty"`
-	Transaction  *Transaction  `xml:"errors>transaction,omitempty"` // UnprocessableEntity errors return only the transaction
+	Subscription *Subscription
+	Transaction  *Transaction // UnprocessableEntity errors return only the transaction
 }
 
 // UpdateSubscription is used to update subscriptions

--- a/subscriptions_service.go
+++ b/subscriptions_service.go
@@ -75,14 +75,19 @@ func (s *subscriptionsImpl) Get(uuid string) (*Response, *Subscription, error) {
 
 // Create creates a new subscription.
 // https://docs.recurly.com/api/subscriptions#create-subscription
-func (s *subscriptionsImpl) Create(sub NewSubscription) (*Response, *Subscription, error) {
+func (s *subscriptionsImpl) Create(sub NewSubscription) (*Response, *NewSubscriptionResponse, error) {
 	req, err := s.client.newRequest("POST", "subscriptions", nil, sub)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	var dst Subscription
-	resp, err := s.client.do(req, &dst)
+	var dst NewSubscriptionResponse
+	var subscription Subscription
+	resp, err := s.client.do(req, &subscription)
+	dst.Subscription = &subscription
+	if resp.transaction != nil {
+		dst.Transaction = resp.transaction
+	}
 
 	return resp, &dst, err
 }

--- a/subscriptions_service.go
+++ b/subscriptions_service.go
@@ -87,8 +87,8 @@ func (s *subscriptionsImpl) Create(sub NewSubscription) (*Response, *NewSubscrip
 	if subscription.UUID != "" { // If subscription not present, dst.Subscription should be nil
 		dst.Subscription = &subscription
 	}
-	if resp.Transaction != nil {
-		dst.Transaction = resp.Transaction
+	if resp.transaction != nil {
+		dst.Transaction = resp.transaction
 	}
 
 	return resp, &dst, err

--- a/subscriptions_service.go
+++ b/subscriptions_service.go
@@ -84,9 +84,11 @@ func (s *subscriptionsImpl) Create(sub NewSubscription) (*Response, *NewSubscrip
 	var dst NewSubscriptionResponse
 	var subscription Subscription
 	resp, err := s.client.do(req, &subscription)
-	dst.Subscription = &subscription
-	if resp.transaction != nil {
-		dst.Transaction = resp.transaction
+	if subscription.UUID != "" { // If subscription not present, dst.Subscription should be nil
+		dst.Subscription = &subscription
+	}
+	if resp.Transaction != nil {
+		dst.Transaction = resp.Transaction
 	}
 
 	return resp, &dst, err

--- a/subscriptions_test.go
+++ b/subscriptions_test.go
@@ -761,7 +761,7 @@ func TestSubscriptions_Create_TransactionError(t *testing.T) {
 		}
 		w.WriteHeader(http.StatusUnprocessableEntity)
 		fmt.Fprint(w, `<?xml version="1.0" encoding="UTF-8"?>
-            <errors>
+			<errors>
 			  <transaction_error>
 			    <error_code>declined_saveable</error_code>
 			    <error_category>soft</error_category>
@@ -776,17 +776,9 @@ func TestSubscriptions_Create_TransactionError(t *testing.T) {
 			    <uuid>3c42a3ecc46a7aa602602e4033b9c2e6</uuid>
 			    <action>purchase</action>
 			    <amount_in_cents type="integer">5274</amount_in_cents>
-			    <tax_in_cents type="integer">424</tax_in_cents>
-			    <currency>EUR</currency>
+			    <currency>USD</currency>
 			    <status>declined</status>
 			    <payment_method>credit_card</payment_method>
-			    <reference>3383506</reference>
-			    <source>subscription</source>
-			    <recurring type="boolean">false</recurring>
-			    <test type="boolean">true</test>
-			    <voidable type="boolean">false</voidable>
-			    <refundable type="boolean">false</refundable>
-			    <ip_address>127.0.0.1</ip_address>
 			    <transaction_error>
 			      <error_code>declined_saveable</error_code>
 			      <error_category>soft</error_category>
@@ -794,37 +786,7 @@ func TestSubscriptions_Create_TransactionError(t *testing.T) {
 			      <customer_message>The transaction was declined. Please use a different card or contact your bank.</customer_message>
 			      <gateway_error_code nil="nil"/>
 			    </transaction_error>
-			    <cvv_result code="" nil="nil"/>
-			    <avs_result code="" nil="nil"/>
-			    <avs_result_street nil="nil"/>
-			    <avs_result_postal nil="nil"/>
-			    <created_at type="datetime">2017-03-15T21:21:16Z</created_at>
-			    <updated_at type="datetime">2017-03-15T21:21:16Z</updated_at>
-			    <details>
-			      <account>
-			        <account_code>1</account_code>
-			        <first_name>Verena</first_name>
-			        <last_name>Example</last_name>
-			        <company>New Company Name</company>
-			        <email>verena@example.com</email>
-			        <billing_info type="credit_card">
-			          <first_name>Verena</first_name>
-			          <last_name>Example</last_name>
-			          <address1>123 Main St.</address1>
-			          <address2 nil="nil"/>
-			          <city>San Francisco</city>
-			          <state>CA</state>
-			          <zip>94105</zip>
-			          <country>US</country>
-			          <phone nil="nil"/>
-			          <vat_number nil="nil"/>
-			          <card_type>Visa</card_type>
-			          <year type="integer">2019</year>
-			          <month type="integer">12</month>
-			          <first_six>400000</first_six>
-			          <last_four>0341</last_four>
-			        </billing_info>
-			      </account>
+				<details>
 			    </details>
 			  </transaction>
 			</errors>`)
@@ -837,14 +799,25 @@ func TestSubscriptions_Create_TransactionError(t *testing.T) {
 		t.Fatal("expected create subscription to return OK")
 	} else if newSubscription.Transaction == nil {
 		t.Fatal("expected transaction to be set")
-	} else if !reflect.DeepEqual(newSubscription.Transaction.TransactionError, &recurly.TransactionError{
-		XMLName:         xml.Name{Local: "transaction_error"},
-		ErrorCode:       "declined_saveable",
-		ErrorCategory:   "soft",
-		MerchantMessage: "The transaction was declined without specific information.  Please contact your payment gateway for more details or ask the customer to contact their bank.",
-		CustomerMessage: "The transaction was declined. Please use a different card or contact your bank.",
+	} else if !reflect.DeepEqual(newSubscription.Transaction, &recurly.Transaction{
+		UUID:             "3c42a3ecc46a7aa602602e4033b9c2e6",
+		SubscriptionUUID: "3c42a3ebabdc022739d5a646408291a6",
+		Action:           "purchase",
+		AmountInCents:    5274,
+		Currency:         "USD",
+		Status:           "declined",
+		PaymentMethod:    "credit_card",
+		TransactionError: &recurly.TransactionError{
+			XMLName:         xml.Name{Local: "transaction_error"},
+			ErrorCode:       "declined_saveable",
+			ErrorCategory:   "soft",
+			MerchantMessage: "The transaction was declined without specific information.  Please contact your payment gateway for more details or ask the customer to contact their bank.",
+			CustomerMessage: "The transaction was declined. Please use a different card or contact your bank.",
+		},
 	}) {
 		t.Fatalf("unexpected transaction error: %v", newSubscription.Transaction.TransactionError)
+	} else if newSubscription.Subscription != nil {
+		t.Fatalf("unexpected subscription: %v", newSubscription.Subscription)
 	}
 }
 

--- a/subscriptions_test.go
+++ b/subscriptions_test.go
@@ -759,28 +759,92 @@ func TestSubscriptions_Create_TransactionError(t *testing.T) {
 		if r.Method != "POST" {
 			t.Fatalf("unexpected method: %s", r.Method)
 		}
-		w.WriteHeader(422)
+		w.WriteHeader(http.StatusUnprocessableEntity)
 		fmt.Fprint(w, `<?xml version="1.0" encoding="UTF-8"?>
-			<errors>
+            <errors>
 			  <transaction_error>
-			    <error_code>fraud_security_code</error_code>
+			    <error_code>declined_saveable</error_code>
+			    <error_category>soft</error_category>
+			    <merchant_message>The transaction was declined without specific information.  Please contact your payment gateway for more details or ask the customer to contact their bank.</merchant_message>
+			    <customer_message>The transaction was declined. Please use a different card or contact your bank.</customer_message>
+			    <gateway_error_code nil="nil"/>
 			  </transaction_error>
-			  <error field="transaction.account.billing_info.verification_value" symbol="declined_bad">did not match</error>
-			  <transaction href="https://your-subdomain.recurly.com/v2/transactions/3d1c6aa86e3d447eb0f3b4a6e3e074d9" type="credit_card">
-			    <uuid>3d1c6aa86e3d447eb0f3b4a6e3e074d9</uuid>
+			  <error field="subscription.account.base" symbol="declined_saveable">The transaction was declined. Please use a different card or contact your bank.</error>
+			  <transaction href="https://your-subdomain.recurly.com/v2/transactions/3c42a3ecc46a7aa602602e4033b9c2e6" type="credit_card">
+			    <account href="https://your-subdomain.recurly.com/v2/accounts/1"/>
+			    <subscription href="https://your-subdomain.recurly.com/v2/subscriptions/3c42a3ebabdc022739d5a646408291a6"/>
+			    <uuid>3c42a3ecc46a7aa602602e4033b9c2e6</uuid>
+			    <action>purchase</action>
+			    <amount_in_cents type="integer">5274</amount_in_cents>
+			    <tax_in_cents type="integer">424</tax_in_cents>
+			    <currency>EUR</currency>
+			    <status>declined</status>
+			    <payment_method>credit_card</payment_method>
+			    <reference>3383506</reference>
+			    <source>subscription</source>
+			    <recurring type="boolean">false</recurring>
+			    <test type="boolean">true</test>
+			    <voidable type="boolean">false</voidable>
+			    <refundable type="boolean">false</refundable>
+			    <ip_address>127.0.0.1</ip_address>
+			    <transaction_error>
+			      <error_code>declined_saveable</error_code>
+			      <error_category>soft</error_category>
+			      <merchant_message>The transaction was declined without specific information.  Please contact your payment gateway for more details or ask the customer to contact their bank.</merchant_message>
+			      <customer_message>The transaction was declined. Please use a different card or contact your bank.</customer_message>
+			      <gateway_error_code nil="nil"/>
+			    </transaction_error>
+			    <cvv_result code="" nil="nil"/>
+			    <avs_result code="" nil="nil"/>
+			    <avs_result_street nil="nil"/>
+			    <avs_result_postal nil="nil"/>
+			    <created_at type="datetime">2017-03-15T21:21:16Z</created_at>
+			    <updated_at type="datetime">2017-03-15T21:21:16Z</updated_at>
+			    <details>
+			      <account>
+			        <account_code>1</account_code>
+			        <first_name>Verena</first_name>
+			        <last_name>Example</last_name>
+			        <company>New Company Name</company>
+			        <email>verena@example.com</email>
+			        <billing_info type="credit_card">
+			          <first_name>Verena</first_name>
+			          <last_name>Example</last_name>
+			          <address1>123 Main St.</address1>
+			          <address2 nil="nil"/>
+			          <city>San Francisco</city>
+			          <state>CA</state>
+			          <zip>94105</zip>
+			          <country>US</country>
+			          <phone nil="nil"/>
+			          <vat_number nil="nil"/>
+			          <card_type>Visa</card_type>
+			          <year type="integer">2019</year>
+			          <month type="integer">12</month>
+			          <first_six>400000</first_six>
+			          <last_four>0341</last_four>
+			        </billing_info>
+			      </account>
+			    </details>
 			  </transaction>
 			</errors>`)
 	})
 
-	r, _, err := client.Subscriptions.Create(recurly.NewSubscription{})
+	r, newSubscription, err := client.Subscriptions.Create(recurly.NewSubscription{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	} else if !r.IsError() {
 		t.Fatal("expected create subscription to return OK")
-	} else if r.Transaction.UUID != "3d1c6aa86e3d447eb0f3b4a6e3e074d9" {
-		t.Fatalf("unexpected transaction uuid: %s", r.Transaction.UUID)
-	} else if r.TransactionError.ErrorCode != "fraud_security_code" {
-		t.Fatalf("unexpected transaction error code: %s", r.TransactionError.ErrorCode)
+	} else if newSubscription.Transaction == nil {
+		t.Fatal("expected transaction to be set")
+	} else if !reflect.DeepEqual(newSubscription.Transaction.TransactionError, &recurly.TransactionError{
+		XMLName:         xml.Name{Local: "transaction_error"},
+		ErrorCode:       "declined_saveable",
+		ErrorCategory:   "soft",
+		MerchantMessage: "The transaction was declined without specific information.  Please contact your payment gateway for more details or ask the customer to contact their bank.",
+		CustomerMessage: "The transaction was declined. Please use a different card or contact your bank.",
+	}) {
+		t.Fatalf("unexpected transaction error: %v", newSubscription.Transaction.TransactionError)
 	}
 }
 

--- a/transactions.go
+++ b/transactions.go
@@ -34,12 +34,12 @@ type Transaction struct {
 	Voidable         NullBool
 	Refundable       NullBool
 	IPAddress        net.IP
-	TransactionError TransactionError // Read only
-	CVVResult        CVVResult        // Read only
-	AVSResult        AVSResult        // Read only
-	AVSResultStreet  string           // Read only
-	AVSResultPostal  string           // Read only
-	CreatedAt        NullTime         // Read only
+	TransactionError *TransactionError // Read only
+	CVVResult        CVVResult         // Read only
+	AVSResult        AVSResult         // Read only
+	AVSResultStreet  string            // Read only
+	AVSResultPostal  string            // Read only
+	CreatedAt        NullTime          // Read only
 	Account          Account
 }
 
@@ -144,7 +144,7 @@ func (t *Transaction) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error
 		Voidable:         v.Voidable,
 		Refundable:       v.Refundable,
 		IPAddress:        v.IPAddress,
-		TransactionError: v.TransactionError,
+		TransactionError: &v.TransactionError,
 		CVVResult:        v.CVVResult,
 		AVSResult:        v.AVSResult,
 		AVSResultStreet:  v.AVSResultStreet,

--- a/transactions.go
+++ b/transactions.go
@@ -99,30 +99,30 @@ func (t Transaction) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 // for types like href.
 func (t *Transaction) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	var v struct {
-		XMLName          xml.Name         `xml:"transaction"`
-		InvoiceNumber    hrefInt          `xml:"invoice"`      // use hrefInt for parsing
-		SubscriptionUUID hrefString       `xml:"subscription"` // use hrefString for parsing
-		UUID             string           `xml:"uuid,omitempty"`
-		Action           string           `xml:"action,omitempty"`
-		AmountInCents    int              `xml:"amount_in_cents"`
-		TaxInCents       int              `xml:"tax_in_cents,omitempty"`
-		Currency         string           `xml:"currency"`
-		Status           string           `xml:"status,omitempty"`
-		PaymentMethod    string           `xml:"payment_method,omitempty"`
-		Reference        string           `xml:"reference,omitempty"`
-		Source           string           `xml:"source,omitempty"`
-		Recurring        NullBool         `xml:"recurring,omitempty"`
-		Test             bool             `xml:"test,omitempty"`
-		Voidable         NullBool         `xml:"voidable,omitempty"`
-		Refundable       NullBool         `xml:"refundable,omitempty"`
-		IPAddress        net.IP           `xml:"ip_address,omitempty"`
-		TransactionError TransactionError `xml:"transaction_error,omitempty"`
-		CVVResult        CVVResult        `xml:"cvv_result"`
-		AVSResult        AVSResult        `xml:"avs_result"`
-		AVSResultStreet  string           `xml:"avs_result_street,omitempty"`
-		AVSResultPostal  string           `xml:"avs_result_postal,omitempty"`
-		CreatedAt        NullTime         `xml:"created_at,omitempty"`
-		Account          Account          `xml:"details>account"`
+		XMLName          xml.Name          `xml:"transaction"`
+		InvoiceNumber    hrefInt           `xml:"invoice"`      // use hrefInt for parsing
+		SubscriptionUUID hrefString        `xml:"subscription"` // use hrefString for parsing
+		UUID             string            `xml:"uuid,omitempty"`
+		Action           string            `xml:"action,omitempty"`
+		AmountInCents    int               `xml:"amount_in_cents"`
+		TaxInCents       int               `xml:"tax_in_cents,omitempty"`
+		Currency         string            `xml:"currency"`
+		Status           string            `xml:"status,omitempty"`
+		PaymentMethod    string            `xml:"payment_method,omitempty"`
+		Reference        string            `xml:"reference,omitempty"`
+		Source           string            `xml:"source,omitempty"`
+		Recurring        NullBool          `xml:"recurring,omitempty"`
+		Test             bool              `xml:"test,omitempty"`
+		Voidable         NullBool          `xml:"voidable,omitempty"`
+		Refundable       NullBool          `xml:"refundable,omitempty"`
+		IPAddress        net.IP            `xml:"ip_address,omitempty"`
+		TransactionError *TransactionError `xml:"transaction_error,omitempty"`
+		CVVResult        CVVResult         `xml:"cvv_result"`
+		AVSResult        AVSResult         `xml:"avs_result"`
+		AVSResultStreet  string            `xml:"avs_result_street,omitempty"`
+		AVSResultPostal  string            `xml:"avs_result_postal,omitempty"`
+		CreatedAt        NullTime          `xml:"created_at,omitempty"`
+		Account          Account           `xml:"details>account"`
 	}
 	if err := d.DecodeElement(&v, &start); err != nil {
 		return err
@@ -144,13 +144,16 @@ func (t *Transaction) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error
 		Voidable:         v.Voidable,
 		Refundable:       v.Refundable,
 		IPAddress:        v.IPAddress,
-		TransactionError: &v.TransactionError,
 		CVVResult:        v.CVVResult,
 		AVSResult:        v.AVSResult,
 		AVSResultStreet:  v.AVSResultStreet,
 		AVSResultPostal:  v.AVSResultPostal,
 		CreatedAt:        v.CreatedAt,
 		Account:          v.Account,
+	}
+
+	if v.TransactionError != nil {
+		t.TransactionError = v.TransactionError
 	}
 
 	return nil

--- a/transactions.go
+++ b/transactions.go
@@ -34,12 +34,25 @@ type Transaction struct {
 	Voidable         NullBool
 	Refundable       NullBool
 	IPAddress        net.IP
-	CVVResult        CVVResult // Read only
-	AVSResult        AVSResult // Read only
-	AVSResultStreet  string    // Read only
-	AVSResultPostal  string    // Read only
-	CreatedAt        NullTime  // Read only
+	TransactionError TransactionError // Read only
+	CVVResult        CVVResult        // Read only
+	AVSResult        AVSResult        // Read only
+	AVSResultStreet  string           // Read only
+	AVSResultPostal  string           // Read only
+	CreatedAt        NullTime         // Read only
 	Account          Account
+}
+
+// TransactionError is an error encounted from your payment gateway that
+// recurly has standardized.
+// https://recurly.readme.io/v2.0/page/transaction-errors
+type TransactionError struct {
+	XMLName          xml.Name `xml:"transaction_error"`
+	ErrorCode        string   `xml:"error_code,omitempty"`
+	ErrorCategory    string   `xml:"error_category,omitempty"`
+	MerchantMessage  string   `xml:"merchant_message,omitempty"`
+	CustomerMessage  string   `xml:"customer_message,omitempty"`
+	GatewayErrorCode string   `xml:"gateway_error_code,omitempty"`
 }
 
 // MarshalXML marshals a transaction sending only the fields recurly allows for writes.
@@ -86,29 +99,30 @@ func (t Transaction) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 // for types like href.
 func (t *Transaction) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	var v struct {
-		XMLName          xml.Name   `xml:"transaction"`
-		InvoiceNumber    hrefInt    `xml:"invoice"`      // use hrefInt for parsing
-		SubscriptionUUID hrefString `xml:"subscription"` // use hrefString for parsing
-		UUID             string     `xml:"uuid,omitempty"`
-		Action           string     `xml:"action,omitempty"`
-		AmountInCents    int        `xml:"amount_in_cents"`
-		TaxInCents       int        `xml:"tax_in_cents,omitempty"`
-		Currency         string     `xml:"currency"`
-		Status           string     `xml:"status,omitempty"`
-		PaymentMethod    string     `xml:"payment_method,omitempty"`
-		Reference        string     `xml:"reference,omitempty"`
-		Source           string     `xml:"source,omitempty"`
-		Recurring        NullBool   `xml:"recurring,omitempty"`
-		Test             bool       `xml:"test,omitempty"`
-		Voidable         NullBool   `xml:"voidable,omitempty"`
-		Refundable       NullBool   `xml:"refundable,omitempty"`
-		IPAddress        net.IP     `xml:"ip_address,omitempty"`
-		CVVResult        CVVResult  `xml:"cvv_result"`
-		AVSResult        AVSResult  `xml:"avs_result"`
-		AVSResultStreet  string     `xml:"avs_result_street,omitempty"`
-		AVSResultPostal  string     `xml:"avs_result_postal,omitempty"`
-		CreatedAt        NullTime   `xml:"created_at,omitempty"`
-		Account          Account    `xml:"details>account"`
+		XMLName          xml.Name         `xml:"transaction"`
+		InvoiceNumber    hrefInt          `xml:"invoice"`      // use hrefInt for parsing
+		SubscriptionUUID hrefString       `xml:"subscription"` // use hrefString for parsing
+		UUID             string           `xml:"uuid,omitempty"`
+		Action           string           `xml:"action,omitempty"`
+		AmountInCents    int              `xml:"amount_in_cents"`
+		TaxInCents       int              `xml:"tax_in_cents,omitempty"`
+		Currency         string           `xml:"currency"`
+		Status           string           `xml:"status,omitempty"`
+		PaymentMethod    string           `xml:"payment_method,omitempty"`
+		Reference        string           `xml:"reference,omitempty"`
+		Source           string           `xml:"source,omitempty"`
+		Recurring        NullBool         `xml:"recurring,omitempty"`
+		Test             bool             `xml:"test,omitempty"`
+		Voidable         NullBool         `xml:"voidable,omitempty"`
+		Refundable       NullBool         `xml:"refundable,omitempty"`
+		IPAddress        net.IP           `xml:"ip_address,omitempty"`
+		TransactionError TransactionError `xml:"transaction_error,omitempty"`
+		CVVResult        CVVResult        `xml:"cvv_result"`
+		AVSResult        AVSResult        `xml:"avs_result"`
+		AVSResultStreet  string           `xml:"avs_result_street,omitempty"`
+		AVSResultPostal  string           `xml:"avs_result_postal,omitempty"`
+		CreatedAt        NullTime         `xml:"created_at,omitempty"`
+		Account          Account          `xml:"details>account"`
 	}
 	if err := d.DecodeElement(&v, &start); err != nil {
 		return err
@@ -130,6 +144,7 @@ func (t *Transaction) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error
 		Voidable:         v.Voidable,
 		Refundable:       v.Refundable,
 		IPAddress:        v.IPAddress,
+		TransactionError: v.TransactionError,
 		CVVResult:        v.CVVResult,
 		AVSResult:        v.AVSResult,
 		AVSResultStreet:  v.AVSResultStreet,

--- a/transactions_service.go
+++ b/transactions_service.go
@@ -92,5 +92,11 @@ func (s *transactionsImpl) Create(t Transaction) (*Response, *Transaction, error
 	var dst Transaction
 	resp, err := s.client.do(req, &dst)
 
+	// If there is an error set the response transaction as the returned transaction
+	// so that the caller has access to TransactionError.
+	if resp.IsError() {
+		dst = *resp.transaction
+	}
+
 	return resp, &dst, err
 }

--- a/transactions_service.go
+++ b/transactions_service.go
@@ -95,7 +95,9 @@ func (s *transactionsImpl) Create(t Transaction) (*Response, *Transaction, error
 	// If there is an error set the response transaction as the returned transaction
 	// so that the caller has access to TransactionError.
 	if resp.IsError() {
-		dst = *resp.transaction
+		if resp.Transaction != nil {
+			dst = *resp.Transaction
+		}
 	}
 
 	return resp, &dst, err

--- a/transactions_service.go
+++ b/transactions_service.go
@@ -95,8 +95,8 @@ func (s *transactionsImpl) Create(t Transaction) (*Response, *Transaction, error
 	// If there is an error set the response transaction as the returned transaction
 	// so that the caller has access to TransactionError.
 	if resp.IsError() {
-		if resp.Transaction != nil {
-			dst = *resp.Transaction
+		if resp.transaction != nil {
+			dst = *resp.transaction
 		}
 	}
 

--- a/transactions_test.go
+++ b/transactions_test.go
@@ -121,7 +121,6 @@ func TestTransactions_List(t *testing.T) {
 			Voidable:         recurly.NewBool(true),
 			Refundable:       recurly.NewBool(true),
 			IPAddress:        net.ParseIP("127.0.0.1"),
-			TransactionError: &recurly.TransactionError{},
 			CVVResult: recurly.CVVResult{
 				recurly.TransactionResult{
 					Code:    "M",
@@ -159,6 +158,7 @@ func TestTransactions_List(t *testing.T) {
 			},
 		},
 	}) {
+		fmt.Printf("%v", transactions[0].TransactionError)
 		t.Fatalf("unexpected transaction: %v", transactions)
 	}
 }
@@ -255,7 +255,6 @@ func TestTransactions_ListAccount(t *testing.T) {
 			Voidable:         recurly.NewBool(true),
 			Refundable:       recurly.NewBool(true),
 			IPAddress:        net.ParseIP("127.0.0.1"),
-			TransactionError: &recurly.TransactionError{},
 			CVVResult: recurly.CVVResult{
 				recurly.TransactionResult{
 					Code:    "M",
@@ -384,7 +383,6 @@ func TestTransactions_Get(t *testing.T) {
 		Voidable:         recurly.NewBool(true),
 		Refundable:       recurly.NewBool(true),
 		IPAddress:        net.ParseIP("127.0.0.1"),
-		TransactionError: &recurly.TransactionError{},
 		CVVResult: recurly.CVVResult{
 			recurly.TransactionResult{
 				Code:    "M",
@@ -509,13 +507,6 @@ func TestTransactions_Err_FraudCard(t *testing.T) {
 			    <currency>USD</currency>
 			    <status>declined</status>
 			    <payment_method>credit_card</payment_method>
-			    <reference>6223543</reference>
-			    <source>transaction</source>
-			    <recurring type="boolean">false</recurring>
-			    <test type="boolean">true</test>
-			    <voidable type="boolean">false</voidable>
-			    <refundable type="boolean">false</refundable>
-			    <ip_address>184.23.184.210</ip_address>
 			    <transaction_error>
 			      <error_code>fraud_gateway</error_code>
 			      <error_category>fraud</error_category>
@@ -523,36 +514,7 @@ func TestTransactions_Err_FraudCard(t *testing.T) {
 			      <customer_message>The transaction was declined. Please use a different card, contact your bank, or contact support.</customer_message>
 			      <gateway_error_code nil="nil"></gateway_error_code>
 			    </transaction_error>
-			    <cvv_result code="" nil="nil"></cvv_result>
-			    <avs_result code="" nil="nil"></avs_result>
-			    <avs_result_street nil="nil"></avs_result_street>
-			    <avs_result_postal nil="nil"></avs_result_postal>
-			    <created_at type="datetime">2015-07-31T20:45:01Z</created_at>
 			    <details>
-			      <account>
-			        <account_code>1</account_code>
-			        <first_name>Verena</first_name>
-			        <last_name>Example</last_name>
-			        <company></company>
-			        <email></email>
-			        <billing_info type="credit_card">
-			          <first_name>Verena</first_name>
-			          <last_name>Example</last_name>
-			          <address1>123 Main St.</address1>
-			          <address2></address2>
-			          <city>San Francisco</city>
-			          <state>CA</state>
-			          <zip>94133</zip>
-			          <country>US</country>
-			          <phone nil="nil"></phone>
-			          <vat_number nil="nil"></vat_number>
-			          <card_type>Visa</card_type>
-			          <year type="integer">2020</year>
-			          <month type="integer">10</month>
-			          <first_six>400000</first_six>
-			          <last_four>0085</last_four>
-			        </billing_info>
-			      </account>
 			    </details>
 			  </transaction>
 			</errors>`)
@@ -576,14 +538,22 @@ func TestTransactions_Err_FraudCard(t *testing.T) {
 		t.Fatalf("error occurred making API call. Err: %s", err)
 	} else if r.IsOK() {
 		t.Fatal("expected create fraudulent transaction to return error")
-	} else if !reflect.DeepEqual(transaction.TransactionError, &recurly.TransactionError{
-		XMLName:         xml.Name{Local: "transaction_error"},
-		ErrorCode:       "fraud_gateway",
-		ErrorCategory:   "fraud",
-		MerchantMessage: "The payment gateway declined the transaction due to fraud filters enabled in your gateway.",
-		CustomerMessage: "The transaction was declined. Please use a different card, contact your bank, or contact support.",
+	} else if !reflect.DeepEqual(transaction, &recurly.Transaction{
+		UUID:          "3054a79e4c3ab4699f95be455f8653bb",
+		Action:        "purchase",
+		AmountInCents: 100,
+		Currency:      "USD",
+		Status:        "declined",
+		PaymentMethod: "credit_card",
+		TransactionError: &recurly.TransactionError{
+			XMLName:         xml.Name{Local: "transaction_error"},
+			ErrorCode:       "fraud_gateway",
+			ErrorCategory:   "fraud",
+			MerchantMessage: "The payment gateway declined the transaction due to fraud filters enabled in your gateway.",
+			CustomerMessage: "The transaction was declined. Please use a different card, contact your bank, or contact support.",
+		},
 	}) {
-		t.Fatalf("error did not match: %v", transaction.TransactionError)
+		t.Fatalf("unexpected transaction: %#v", transaction)
 	}
 }
 

--- a/transactions_test.go
+++ b/transactions_test.go
@@ -121,6 +121,7 @@ func TestTransactions_List(t *testing.T) {
 			Voidable:         recurly.NewBool(true),
 			Refundable:       recurly.NewBool(true),
 			IPAddress:        net.ParseIP("127.0.0.1"),
+			TransactionError: &recurly.TransactionError{},
 			CVVResult: recurly.CVVResult{
 				recurly.TransactionResult{
 					Code:    "M",
@@ -254,6 +255,7 @@ func TestTransactions_ListAccount(t *testing.T) {
 			Voidable:         recurly.NewBool(true),
 			Refundable:       recurly.NewBool(true),
 			IPAddress:        net.ParseIP("127.0.0.1"),
+			TransactionError: &recurly.TransactionError{},
 			CVVResult: recurly.CVVResult{
 				recurly.TransactionResult{
 					Code:    "M",
@@ -382,6 +384,7 @@ func TestTransactions_Get(t *testing.T) {
 		Voidable:         recurly.NewBool(true),
 		Refundable:       recurly.NewBool(true),
 		IPAddress:        net.ParseIP("127.0.0.1"),
+		TransactionError: &recurly.TransactionError{},
 		CVVResult: recurly.CVVResult{
 			recurly.TransactionResult{
 				Code:    "M",
@@ -555,7 +558,7 @@ func TestTransactions_Err_FraudCard(t *testing.T) {
 			</errors>`)
 	})
 
-	r, _, err := client.Transactions.Create(recurly.Transaction{
+	r, transaction, err := client.Transactions.Create(recurly.Transaction{
 		AmountInCents: 100,
 		Currency:      "USD",
 		Account: recurly.Account{
@@ -573,14 +576,14 @@ func TestTransactions_Err_FraudCard(t *testing.T) {
 		t.Fatalf("error occurred making API call. Err: %s", err)
 	} else if r.IsOK() {
 		t.Fatal("expected create fraudulent transaction to return error")
-	} else if !reflect.DeepEqual(r.TransactionError, &recurly.TransactionError{
+	} else if !reflect.DeepEqual(transaction.TransactionError, &recurly.TransactionError{
 		XMLName:         xml.Name{Local: "transaction_error"},
 		ErrorCode:       "fraud_gateway",
 		ErrorCategory:   "fraud",
 		MerchantMessage: "The payment gateway declined the transaction due to fraud filters enabled in your gateway.",
 		CustomerMessage: "The transaction was declined. Please use a different card, contact your bank, or contact support.",
 	}) {
-		t.Fatalf("error did not match: %v", r.TransactionError)
+		t.Fatalf("error did not match: %v", transaction.TransactionError)
 	}
 }
 

--- a/transactions_test.go
+++ b/transactions_test.go
@@ -158,7 +158,6 @@ func TestTransactions_List(t *testing.T) {
 			},
 		},
 	}) {
-		fmt.Printf("%v", transactions[0].TransactionError)
 		t.Fatalf("unexpected transaction: %v", transactions)
 	}
 }


### PR DESCRIPTION
This PR adds the `TransactionError` struct to the `Transaction` struct so that it can be returned with transactions where applicable. Example use case in tests. 