### PR TITLE
Custom XML unmarshaler for Billing struct

### DIFF
--- a/billing.go
+++ b/billing.go
@@ -52,6 +52,84 @@ type Billing struct {
 	Token string `xml:"token_id,omitempty"`
 }
 
+// UnmarshalXML is a customer XML unmarshaler for billing info that supports
+// unmarshaling null fields without errors.
+func (b *Billing) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	var v struct {
+		XMLName          xml.Name `xml:"billing_info"`
+		FirstName        string   `xml:"first_name,omitempty"`
+		LastName         string   `xml:"last_name,omitempty"`
+		Company          string   `xml:"company,omitempty"`
+		Address          string   `xml:"address1,omitempty"`
+		Address2         string   `xml:"address2,omitempty"`
+		City             string   `xml:"city,omitempty"`
+		State            string   `xml:"state,omitempty"`
+		Zip              string   `xml:"zip,omitempty"`
+		Country          string   `xml:"country,omitempty"`
+		Phone            string   `xml:"phone,omitempty"`
+		VATNumber        string   `xml:"vat_number,omitempty"`
+		IPAddress        net.IP   `xml:"ip_address,omitempty"`
+		IPAddressCountry string   `xml:"ip_address_country,omitempty"`
+
+		// Credit Card Info
+		FirstSix NullInt `xml:"first_six,omitempty"`
+		LastFour NullInt `xml:"last_four,omitempty"`
+		CardType string  `xml:"card_type,omitempty"`
+		Number   int     `xml:"number,omitempty"`
+		Month    NullInt `xml:"month,omitempty"`
+		Year     NullInt `xml:"year,omitempty"`
+
+		// Paypal
+		PaypalAgreementID string `xml:"paypal_billing_agreement_id,omitempty"`
+
+		// Amazon
+		AmazonAgreementID string `xml:"amazon_billing_agreement_id,omitempty"`
+
+		// Bank Account
+		// Note: routing numbers and account numbers may start with zeros, so need
+		// to treat them as strings
+		NameOnAccount string `xml:"name_on_account,omitempty"`
+		RoutingNumber string `xml:"routing_number,omitempty"`
+		AccountNumber string `xml:"account_number,omitempty"`
+		AccountType   string `xml:"account_type,omitempty"`
+	}
+	if err := d.DecodeElement(&v, &start); err != nil {
+		return err
+	}
+	*b = Billing{
+		XMLName:          v.XMLName,
+		FirstName:        v.FirstName,
+		LastName:         v.LastName,
+		Company:          v.Company,
+		Address:          v.Address,
+		Address2:         v.Address2,
+		City:             v.City,
+		State:            v.State,
+		Zip:              v.Zip,
+		Country:          v.Country,
+		Phone:            v.Phone,
+		VATNumber:        v.VATNumber,
+		IPAddress:        v.IPAddress,
+		IPAddressCountry: v.IPAddressCountry,
+
+		FirstSix: v.FirstSix.Int,
+		LastFour: v.LastFour.Int,
+		CardType: v.CardType,
+		Number:   v.Number,
+		Month:    v.Month.Int,
+		Year:     v.Year.Int,
+
+		PaypalAgreementID: v.PaypalAgreementID,
+		AmazonAgreementID: v.AmazonAgreementID,
+
+		NameOnAccount: v.NameOnAccount,
+		RoutingNumber: v.RoutingNumber,
+		AccountNumber: v.AccountNumber,
+		AccountType:   v.AccountType,
+	}
+	return nil
+}
+
 // Type returns the billing info type. Currently options: card, bank, ""
 func (b Billing) Type() string {
 	if b.FirstSix > 0 && b.LastFour > 0 && b.Month > 0 && b.Year > 0 {


### PR DESCRIPTION
ACH accounts do not contain all of the billing info credit card customers do. As a result, an ACH account with no credit card info will trigger `strconv.ParseInt` errors. Even if the account has card info on file, if a particular transaction was processed via ACH the nested `billing_info` struct will trigger this error.

This PR adds a custom XML unmarshaler for the `Billing` struct with a corresponding test that would otherwise fail without the custom unmarshaler.