### PR TITLE
Allow client to unmarshal single error 422 responses

### DIFF
--- a/responses.go
+++ b/responses.go
@@ -95,8 +95,9 @@ func (r *Response) Next() string {
 
 // Error is an individual validation error
 type Error struct {
-	XMLName xml.Name `xml:"error"`
-	Message string   `xml:",innerxml"`
-	Field   string   `xml:"field,attr"`
-	Symbol  string   `xml:"symbol,attr"`
+	XMLName     xml.Name `xml:"error"`
+	Message     string   `xml:",innerxml"`
+	Field       string   `xml:"field,attr"`
+	Symbol      string   `xml:"symbol,attr"`
+	Description string   `xml:"-"`
 }


### PR DESCRIPTION
Recurly documentation for `422 Unprocessable Entity` was recently updated to include an edge case single `<error>` response instead of an array of `<errors>` which is typically returned. When this occurs this service returns `expected <errors> have <error>`. This PR updates the Recurly `client` to unmarshal a single `<error>` response and set it as the first element in the `Errors` array. 
 
https://dev.recurly.com/docs/welcome#section-422-unprocessable-entity-responses 