### PR TITLE
Add description and product code fields to transactions

### DIFF
--- a/transactions.go
+++ b/transactions.go
@@ -26,6 +26,8 @@ type Transaction struct {
 	TaxInCents       int
 	Currency         string
 	Status           string
+	Description      string
+	ProductCode      string // Write only field, is saved on the invoice line item but not the transaction
 	PaymentMethod    string
 	Reference        string
 	Source           string
@@ -66,6 +68,8 @@ func (t Transaction) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 		TaxInCents    int      `xml:"tax_in_cents,omitempty"`
 		Currency      string   `xml:"currency"`
 		Status        string   `xml:"status,omitempty"`
+		Description   string   `xml:"description,omitempty"`
+		ProductCode   string   `xml:"product_code,omitempty"`
 		PaymentMethod string   `xml:"payment_method,omitempty"`
 		Reference     string   `xml:"reference,omitempty"`
 		Source        string   `xml:"source,omitempty"`
@@ -81,6 +85,8 @@ func (t Transaction) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 		TaxInCents:    t.TaxInCents,
 		Currency:      t.Currency,
 		Status:        t.Status,
+		Description:   t.Description,
+		ProductCode:   t.ProductCode,
 		PaymentMethod: t.PaymentMethod,
 		Reference:     t.Reference,
 		Source:        t.Source,
@@ -108,6 +114,7 @@ func (t *Transaction) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error
 		TaxInCents       int               `xml:"tax_in_cents,omitempty"`
 		Currency         string            `xml:"currency"`
 		Status           string            `xml:"status,omitempty"`
+		Description      string            `xml:"description,omitempty"`
 		PaymentMethod    string            `xml:"payment_method,omitempty"`
 		Reference        string            `xml:"reference,omitempty"`
 		Source           string            `xml:"source,omitempty"`
@@ -136,6 +143,7 @@ func (t *Transaction) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error
 		TaxInCents:       v.TaxInCents,
 		Currency:         v.Currency,
 		Status:           v.Status,
+		Description:      v.Description,
 		PaymentMethod:    v.PaymentMethod,
 		Reference:        v.Reference,
 		Source:           v.Source,

--- a/transactions_test.go
+++ b/transactions_test.go
@@ -315,6 +315,7 @@ func TestTransactions_Get(t *testing.T) {
     		<tax_in_cents type="integer">0</tax_in_cents>
     		<currency>USD</currency>
     		<status>success</status>
+    		<description>Order #717</description>
     		<payment_method>credit_card</payment_method>
     		<reference>5416477</reference>
     		<source>subscription</source>
@@ -374,6 +375,7 @@ func TestTransactions_Get(t *testing.T) {
 		TaxInCents:       0,
 		Currency:         "USD",
 		Status:           "success",
+		Description:      "Order #717",
 		PaymentMethod:    "credit_card",
 		Reference:        "5416477",
 		Source:           "subscription",
@@ -451,7 +453,7 @@ func TestTransactions_New(t *testing.T) {
 			t.Fatalf("unexpected method: %s", r.Method)
 		}
 		defer r.Body.Close()
-		expected := `<transaction><amount_in_cents>100</amount_in_cents><currency>USD</currency><account><account_code>25</account_code></account></transaction>`
+		expected := `<transaction><amount_in_cents>100</amount_in_cents><currency>USD</currency><description>description</description><product_code>code</product_code><account><account_code>25</account_code></account></transaction>`
 		var given bytes.Buffer
 		given.ReadFrom(r.Body)
 		if expected != given.String() {
@@ -469,6 +471,8 @@ func TestTransactions_New(t *testing.T) {
 			Account: recurly.Account{
 				Code: "25",
 			},
+			Description: "description",
+			ProductCode: "code",
 		})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)


### PR DESCRIPTION
This PR adds `Description` and `ProductCode` to transactions as write fields. `ProductCode` can be sent in with new transaction but it becomes part of the adjustment on the invoice and is not returned on `GET` calls for transactions. 