### PR TITLE
Purchase>ShippingAddressID should agree with ShippingAddressService type

### DIFF
--- a/mock/services.go
+++ b/mock/services.go
@@ -438,13 +438,13 @@ type ShippingAddressesService struct {
 	OnCreate      func(accountCode string, address recurly.ShippingAddress) (*recurly.Response, *recurly.ShippingAddress, error)
 	CreateInvoked bool
 
-	OnUpdate      func(accountCode string, shippingAddressID string, address recurly.ShippingAddress) (*recurly.Response, *recurly.ShippingAddress, error)
+	OnUpdate      func(accountCode string, shippingAddressID int64, address recurly.ShippingAddress) (*recurly.Response, *recurly.ShippingAddress, error)
 	UpdateInvoked bool
 
-	OnDelete      func(accountCode string, shippingAddressID string) (*recurly.Response, error)
+	OnDelete      func(accountCode string, shippingAddressID int64) (*recurly.Response, error)
 	DeleteInvoked bool
 
-	OnGetSubscriptions      func(accountCode string, shippingAddress string) (*recurly.Response, []recurly.Subscription, error)
+	OnGetSubscriptions      func(accountCode string, shippingAddress int64) (*recurly.Response, []recurly.Subscription, error)
 	GetSubscriptionsInvoked bool
 }
 
@@ -458,17 +458,17 @@ func (s *ShippingAddressesService) Create(accountCode string, address recurly.Sh
 	return s.OnCreate(accountCode, address)
 }
 
-func (s *ShippingAddressesService) Update(accountCode string, shippingAddressID string, address recurly.ShippingAddress) (*recurly.Response, *recurly.ShippingAddress, error) {
+func (s *ShippingAddressesService) Update(accountCode string, shippingAddressID int64, address recurly.ShippingAddress) (*recurly.Response, *recurly.ShippingAddress, error) {
 	s.UpdateInvoked = true
 	return s.OnUpdate(accountCode, shippingAddressID, address)
 }
 
-func (s *ShippingAddressesService) Delete(accountCode string, shippingAddressID string) (*recurly.Response, error) {
+func (s *ShippingAddressesService) Delete(accountCode string, shippingAddressID int64) (*recurly.Response, error) {
 	s.DeleteInvoked = true
 	return s.Delete(accountCode, shippingAddressID)
 }
 
-func (s *ShippingAddressesService) GetSubscriptions(accountCode string, shippingAddress string) (*recurly.Response, []recurly.Subscription, error) {
+func (s *ShippingAddressesService) GetSubscriptions(accountCode string, shippingAddress int64) (*recurly.Response, []recurly.Subscription, error) {
 	s.GetSubscriptionsInvoked = true
 	return s.GetSubscriptions(accountCode, shippingAddress)
 }

--- a/purchases.go
+++ b/purchases.go
@@ -18,5 +18,5 @@ type Purchase struct {
 	CustomerNotes         string            `xml:"customer_notes,omitempty"`
 	TermsAndConditions    string            `xml:"terms_and_conditions,omitempty"`
 	VATReverseChargeNotes string            `xml:"vat_reverse_charge_notes,omitempty"`
-	ShippingAddressID     int               `xml:"shipping_address_id,omitempty"`
+	ShippingAddressID     string            `xml:"shipping_address_id,omitempty"`
 }

--- a/purchases.go
+++ b/purchases.go
@@ -18,5 +18,5 @@ type Purchase struct {
 	CustomerNotes         string            `xml:"customer_notes,omitempty"`
 	TermsAndConditions    string            `xml:"terms_and_conditions,omitempty"`
 	VATReverseChargeNotes string            `xml:"vat_reverse_charge_notes,omitempty"`
-	ShippingAddressID     string            `xml:"shipping_address_id,omitempty"`
+	ShippingAddressID     int64             `xml:"shipping_address_id,omitempty"`
 }

--- a/purchases_test.go
+++ b/purchases_test.go
@@ -89,8 +89,8 @@ func TestPurchases_Purchase_Encoding(t *testing.T) {
 				"</purchase>",
 		},
 		{
-			v:        recurly.Purchase{ShippingAddressID: "1234"},
-			expected: "<purchase><account></account><adjustments></adjustments><currency></currency><gift_card></gift_card><coupon_codes></coupon_codes><subscriptions></subscriptions><shipping_address_id>1234</shipping_address_id></purchase>",
+			v:        recurly.Purchase{ShippingAddressID: 2438622711411416831},
+			expected: "<purchase><account></account><adjustments></adjustments><currency></currency><gift_card></gift_card><coupon_codes></coupon_codes><subscriptions></subscriptions><shipping_address_id>2438622711411416831</shipping_address_id></purchase>",
 		},
 	}
 

--- a/purchases_test.go
+++ b/purchases_test.go
@@ -88,6 +88,10 @@ func TestPurchases_Purchase_Encoding(t *testing.T) {
 				"<vat_reverse_charge_notes>Vat reverse charge notes.</vat_reverse_charge_notes>" +
 				"</purchase>",
 		},
+		{
+			v:        recurly.Purchase{ShippingAddressID: "1234"},
+			expected: "<purchase><account></account><adjustments></adjustments><currency></currency><gift_card></gift_card><coupon_codes></coupon_codes><subscriptions></subscriptions><shipping_address_id>1234</shipping_address_id></purchase>",
+		},
 	}
 
 	for i, tt := range tests {

--- a/services.go
+++ b/services.go
@@ -98,9 +98,9 @@ type RedemptionsService interface {
 type ShippingAddressesService interface {
 	ListAccount(accountCode string, params Params) (*Response, []ShippingAddress, error)
 	Create(accountCode string, address ShippingAddress) (*Response, *ShippingAddress, error)
-	Update(accountCode string, shippingAddressID string, address ShippingAddress) (*Response, *ShippingAddress, error)
-	Delete(accountCode string, shippingAddressID string) (*Response, error)
-	GetSubscriptions(accountCode string, shippingAddressID string) (*Response, []Subscription, error)
+	Update(accountCode string, shippingAddressID int64, address ShippingAddress) (*Response, *ShippingAddress, error)
+	Delete(accountCode string, shippingAddressID int64) (*Response, error)
+	GetSubscriptions(accountCode string, shippingAddressID int64) (*Response, []Subscription, error)
 }
 
 // SubscriptionsService represents the interactions available for subscriptions.

--- a/shipping_addresses.go
+++ b/shipping_addresses.go
@@ -8,7 +8,7 @@ import (
 type ShippingAddress struct {
 	XMLName     xml.Name `xml:"shipping_address"`
 	AccountCode string   `xml:"account,omitempty"`
-	ID          string   `xml:"id,omitempty"`
+	ID          int64    `xml:"id,omitempty"`
 	FirstName   string   `xml:"first_name"`
 	LastName    string   `xml:"last_name"`
 	Nickname    string   `xml:"nickname,omitempty"`

--- a/shipping_addresses_service.go
+++ b/shipping_addresses_service.go
@@ -42,8 +42,8 @@ func (s *shippingAddressesImpl) Create(accountCode string, shippingAddress Shipp
 }
 
 // Update requests an update to an existing shipping address.
-func (s *shippingAddressesImpl) Update(accountCode string, shippingAddressID string, shippingAddress ShippingAddress) (*Response, *ShippingAddress, error) {
-	action := fmt.Sprintf("accounts/%s/shipping_addresses/%s", accountCode, shippingAddressID)
+func (s *shippingAddressesImpl) Update(accountCode string, shippingAddressID int64, shippingAddress ShippingAddress) (*Response, *ShippingAddress, error) {
+	action := fmt.Sprintf("accounts/%s/shipping_addresses/%d", accountCode, shippingAddressID)
 	req, err := s.client.newRequest("PUT", action, nil, shippingAddress)
 	if err != nil {
 		return nil, nil, err
@@ -55,8 +55,8 @@ func (s *shippingAddressesImpl) Update(accountCode string, shippingAddressID str
 }
 
 // Delete removes a shipping address from an account.
-func (s *shippingAddressesImpl) Delete(accountCode string, shippingAddressID string) (*Response, error) {
-	action := fmt.Sprintf("accounts/%s/shipping_addresses/%s", accountCode, shippingAddressID)
+func (s *shippingAddressesImpl) Delete(accountCode string, shippingAddressID int64) (*Response, error) {
+	action := fmt.Sprintf("accounts/%s/shipping_addresses/%d", accountCode, shippingAddressID)
 	req, err := s.client.newRequest("DELETE", action, nil, nil)
 	if err != nil {
 		return nil, err
@@ -66,8 +66,8 @@ func (s *shippingAddressesImpl) Delete(accountCode string, shippingAddressID str
 }
 
 // GetSubscriptions fetches the subscriptions associated with a shipping address.
-func (s *shippingAddressesImpl) GetSubscriptions(accountCode string, shippingAddressID string) (*Response, []Subscription, error) {
-	action := fmt.Sprintf("accounts/%s/shipping_addresses/%s/subscriptions", accountCode, shippingAddressID)
+func (s *shippingAddressesImpl) GetSubscriptions(accountCode string, shippingAddressID int64) (*Response, []Subscription, error) {
+	action := fmt.Sprintf("accounts/%s/shipping_addresses/%d/subscriptions", accountCode, shippingAddressID)
 	req, err := s.client.newRequest("GET", action, nil, nil)
 	if err != nil {
 		return nil, nil, err

--- a/shipping_addresses_test.go
+++ b/shipping_addresses_test.go
@@ -75,7 +75,7 @@ func TestShippingAddress_ListAccount(t *testing.T) {
 
 	if diff := cmp.Diff(shippingAddresses, []recurly.ShippingAddress{
 		{
-			ID:          "2438622711411416831",
+			ID:          2438622711411416831,
 			AccountCode: "1",
 			Nickname:    "Work",
 			FirstName:   "Verena",
@@ -155,7 +155,7 @@ func TestShippingAddress_Create(t *testing.T) {
 	updated, _ := time.Parse(recurly.DateTimeFormat, "2018-03-19T15:48:00Z")
 
 	if diff := cmp.Diff(shippingAddress, &recurly.ShippingAddress{
-		ID:          "2438622711411416831",
+		ID:          2438622711411416831,
 		AccountCode: "1",
 		Nickname:    "Work",
 		FirstName:   "Verena",
@@ -208,7 +208,7 @@ func TestShippingAddress_Update(t *testing.T) {
 		</shipping_address>`)
 	})
 
-	r, shippingAddress, err := client.ShippingAddresses.Update("1", "2438622711411416831", recurly.ShippingAddress{})
+	r, shippingAddress, err := client.ShippingAddresses.Update("1", 2438622711411416831, recurly.ShippingAddress{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	} else if r.IsError() {
@@ -218,7 +218,7 @@ func TestShippingAddress_Update(t *testing.T) {
 	updated, _ := time.Parse(recurly.DateTimeFormat, "2018-03-19T15:48:00Z")
 
 	if diff := cmp.Diff(shippingAddress, &recurly.ShippingAddress{
-		ID:          "2438622711411416831",
+		ID:          2438622711411416831,
 		AccountCode: "1",
 		Nickname:    "Work",
 		FirstName:   "Verena",
@@ -250,7 +250,7 @@ func TestShippingAddressDelete(t *testing.T) {
 		w.WriteHeader(204)
 	})
 
-	r, err := client.ShippingAddresses.Delete("1", "2438622711411416831")
+	r, err := client.ShippingAddresses.Delete("1", 2438622711411416831)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	} else if r.IsError() {
@@ -302,7 +302,7 @@ func TestShippingAddress_GetSubscriptions(t *testing.T) {
 				</subscription>
 			</subscriptions>`)
 	})
-	resp, subscriptions, err := client.ShippingAddresses.GetSubscriptions("1", "2438622711411416831")
+	resp, subscriptions, err := client.ShippingAddresses.GetSubscriptions("1", 2438622711411416831)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	} else if resp.IsError() {


### PR DESCRIPTION
My initial pass at defining the `Purchase` object happened before the `ShippingAddressService` was established, and I guessed at the type used to model the `ShippingAddressID`, and I guessed wrong.

This changes the `ShippingAddressID` to be a `string` rather than an `int`.