### PR TITLE
Currency field not always required

### DIFF
--- a/adjustments.go
+++ b/adjustments.go
@@ -49,7 +49,7 @@ func (a Adjustment) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 		ProductCode       string   `xml:"product_code,omitempty"`
 		UnitAmountInCents int      `xml:"unit_amount_in_cents"`
 		Quantity          int      `xml:"quantity,omitempty"`
-		Currency          string   `xml:"currency"`
+		Currency          string   `xml:"currency,omitempty"`
 		TaxCode           string   `xml:"tax_code,omitempty"`
 		TaxExempt         NullBool `xml:"tax_exempt,omitempty"`
 		StartDate         NullTime `xml:"start_date,omitempty"`

--- a/adjustments.go
+++ b/adjustments.go
@@ -49,7 +49,7 @@ func (a Adjustment) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 		ProductCode       string   `xml:"product_code,omitempty"`
 		UnitAmountInCents int      `xml:"unit_amount_in_cents"`
 		Quantity          int      `xml:"quantity,omitempty"`
-		Currency          string   `xml:"currency,omitempty"`
+		Currency          string   `xml:"currency,omitempty"` // Required for some operations
 		TaxCode           string   `xml:"tax_code,omitempty"`
 		TaxExempt         NullBool `xml:"tax_exempt,omitempty"`
 		StartDate         NullTime `xml:"start_date,omitempty"`

--- a/adjustments_test.go
+++ b/adjustments_test.go
@@ -25,7 +25,7 @@ func TestAdjustments_Encoding(t *testing.T) {
 		expected string
 	}{
 		// Unit amount in cents and currency are required fields. They should always be present.
-		{v: recurly.Adjustment{}, expected: "<adjustment><unit_amount_in_cents>0</unit_amount_in_cents><currency></currency></adjustment>"},
+		{v: recurly.Adjustment{}, expected: "<adjustment><unit_amount_in_cents>0</unit_amount_in_cents></adjustment>"},
 		{v: recurly.Adjustment{UnitAmountInCents: 2000, Currency: "USD"}, expected: "<adjustment><unit_amount_in_cents>2000</unit_amount_in_cents><currency>USD</currency></adjustment>"},
 		{v: recurly.Adjustment{Description: "Charge for extra bandwidth", ProductCode: "bandwidth", UnitAmountInCents: 2000, Currency: "USD"}, expected: "<adjustment><description>Charge for extra bandwidth</description><product_code>bandwidth</product_code><unit_amount_in_cents>2000</unit_amount_in_cents><currency>USD</currency></adjustment>"},
 		{v: recurly.Adjustment{Quantity: 1, UnitAmountInCents: 2000, Currency: "CAD"}, expected: "<adjustment><unit_amount_in_cents>2000</unit_amount_in_cents><quantity>1</quantity><currency>CAD</currency></adjustment>"},

--- a/purchases_test.go
+++ b/purchases_test.go
@@ -74,7 +74,7 @@ func TestPurchases_Purchase_Encoding(t *testing.T) {
 				"<shipping_addresses><shipping_address><first_name>Lon</first_name><last_name>Doner</last_name><nickname>Home</nickname><address1>221B Baker St.</address1><address2></address2><city>London</city><state></state><zip>W1K 6AH</zip><country>GB</country></shipping_address></shipping_addresses>" +
 				"</account>" +
 				"<adjustments><adjustment>" +
-				"<description>Description of this adjustment</description><product_code>4549449c-5870-4845-b672-1d07f15e87dd</product_code><unit_amount_in_cents>1000</unit_amount_in_cents><quantity>1</quantity><currency></currency>" +
+				"<description>Description of this adjustment</description><product_code>4549449c-5870-4845-b672-1d07f15e87dd</product_code><unit_amount_in_cents>1000</unit_amount_in_cents><quantity>1</quantity>" +
 				// TODO: RevenueScheduleType not yet modeled
 				// "<revenue_schedule_type>at_invoice</revenue_schedule_type>"+
 				"</adjustment></adjustments>" +


### PR DESCRIPTION
When using the existing `Adjustment` object for use against the `Purchases` API, was getting an error with the following text: `The provided XML was invalid. Adjustments cannot contain a child currency tag.`

This just sets the currency element as `omitempty`, and tidies up tests that hard-coded the element.