### PR TITLE
Invoice>DiscountInCents since v2.10

### DIFF
--- a/invoices.go
+++ b/invoices.go
@@ -82,6 +82,7 @@ type Invoice struct {
 	InvoiceNumber           int             `xml:"-"`
 	PONumber                string          `xml:"po_number,omitempty"` // PostInvoice param
 	VATNumber               string          `xml:"-"`
+	DiscountInCents         int             `xml:"-"`
 	SubtotalInCents         int             `xml:"-"`
 	TaxInCents              int             `xml:"-"`
 	TotalInCents            int             `xml:"-"`
@@ -185,6 +186,7 @@ func (i *InvoiceCollection) UnmarshalXML(d *xml.Decoder, start xml.StartElement)
 		InvoiceNumber:           v.ChargeInvoice.InvoiceNumber,
 		PONumber:                v.ChargeInvoice.PONumber,
 		VATNumber:               v.ChargeInvoice.VATNumber,
+		DiscountInCents:         v.ChargeInvoice.DiscountInCents,
 		SubtotalInCents:         v.ChargeInvoice.SubtotalInCents,
 		TaxInCents:              v.ChargeInvoice.TaxInCents,
 		TotalInCents:            v.ChargeInvoice.TotalInCents,
@@ -226,6 +228,7 @@ type invoiceFields struct {
 	InvoiceNumber           int             `xml:"invoice_number,omitempty"`
 	PONumber                string          `xml:"po_number,omitempty"`
 	VATNumber               string          `xml:"vat_number,omitempty"`
+	DiscountInCents         int             `xml:"discount_in_cents,omitempty"`
 	SubtotalInCents         int             `xml:"subtotal_in_cents,omitempty"`
 	TaxInCents              int             `xml:"tax_in_cents,omitempty"`
 	TotalInCents            int             `xml:"total_in_cents,omitempty"`

--- a/invoices_test.go
+++ b/invoices_test.go
@@ -44,6 +44,7 @@ func TestInvoices_List(t *testing.T) {
         		<invoice_number type="integer">1005</invoice_number>
         		<po_number nil="nil"></po_number>
         		<vat_number nil="nil"></vat_number>
+        		<discount_in_cents type="integer">0</discount_in_cents>
         		<subtotal_in_cents type="integer">1200</subtotal_in_cents>
         		<tax_in_cents type="integer">0</tax_in_cents>
         		<total_in_cents type="integer">1200</total_in_cents>
@@ -123,6 +124,7 @@ func TestInvoices_List(t *testing.T) {
 		UUID:             "421f7b7d414e4c6792938e7c49d552e9",
 		State:            recurly.InvoiceStateOpenDeprecated,
 		InvoiceNumber:    1005,
+		DiscountInCents:  0,
 		SubtotalInCents:  1200,
 		TaxInCents:       0,
 		TotalInCents:     1200,


### PR DESCRIPTION
See https://dev.recurly.com/page/api-release-notes#v210-release-notes

Added `discount_in_cents` as a read-only property for `Invoice`.