### PR TITLE
recurly.Error should satisfy the golang error interface

### DIFF
--- a/response_test.go
+++ b/response_test.go
@@ -100,3 +100,20 @@ func TestResponse_CursorLinkParsing(t *testing.T) {
 		t.Fatalf("unexpected next: %s", resp2.Next())
 	}
 }
+
+func TestErrorIfc(t *testing.T) {
+	e := &recurly.Error{
+		Message:     "message",
+		Field:       "field",
+		Symbol:      "symbol",
+		Description: "desc",
+	}
+
+	expected := "error validating field: message, desc, symbol: symbol"
+
+	res := e.Error()
+
+	if expected != res {
+		t.Fatalf("unepected response, expected %s, got %s", expected, res)
+	}
+}

--- a/responses.go
+++ b/responses.go
@@ -2,6 +2,7 @@ package recurly
 
 import (
 	"encoding/xml"
+	"fmt"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -100,4 +101,8 @@ type Error struct {
 	Field       string   `xml:"field,attr"`
 	Symbol      string   `xml:"symbol,attr"`
 	Description string   `xml:"-"`
+}
+
+func (e *Error) Error() string {
+	return fmt.Sprintf("error validating %s: %s, %s, symbol: %s", e.Field, e.Message, e.Description, e.Symbol)
 }


### PR DESCRIPTION
recurly.Error should satisfy the golang error interface so that all clients and users of the library can easily interface with server errors without having to deal with specific recurly error types. This is just a start, feel free to change the formatting