### PR TITLE
Update to v2.15

### DIFF
--- a/accounts.go
+++ b/accounts.go
@@ -37,13 +37,17 @@ type AccountBalance struct {
 
 // Address is used for embedded addresses within other structs.
 type Address struct {
-	Address  string `xml:"address1,omitempty"`
-	Address2 string `xml:"address2,omitempty"`
-	City     string `xml:"city,omitempty"`
-	State    string `xml:"state,omitempty"`
-	Zip      string `xml:"zip,omitempty"`
-	Country  string `xml:"country,omitempty"`
-	Phone    string `xml:"phone,omitempty"`
+	NameOnAccount string `xml:"name_on_account,omitempty"`
+	FirstName     string `xml:"first_name,omitempty"`
+	LastName      string `xml:"last_name,omitempty"`
+	Company       string `xml:"company,omitempty"`
+	Address       string `xml:"address1,omitempty"`
+	Address2      string `xml:"address2,omitempty"`
+	City          string `xml:"city,omitempty"`
+	State         string `xml:"state,omitempty"`
+	Zip           string `xml:"zip,omitempty"`
+	Country       string `xml:"country,omitempty"`
+	Phone         string `xml:"phone,omitempty"`
 }
 
 // MarshalXML ensures addresses marshal to nil if empty without the need

--- a/billing.go
+++ b/billing.go
@@ -5,6 +5,20 @@ import (
 	"net"
 )
 
+// Supported card type constants.
+const (
+	CardTypeAmericanExpress    = "american_express"
+	CardTypeDankort            = "dankort"
+	CardTypeDinersClub         = "diners_club"
+	CardTypeDiscover           = "discover"
+	CardTypeForbrugsforeningen = "forbrugsforeningen"
+	CardTypeJCB                = "jcb"
+	CardTypeLaser              = "laser"
+	CardTypeMaestro            = "maestro"
+	CardTypeMaster             = "master"
+	CardTypeVisa               = "visa"
+)
+
 // Billing represents billing info for a single account on your site
 type Billing struct {
 	XMLName          xml.Name `xml:"billing_info,omitempty"`

--- a/client.go
+++ b/client.go
@@ -115,7 +115,7 @@ func (c *Client) newRequest(method string, action string, params Params, body in
 	))
 	req.Header.Set("Authorization", fmt.Sprintf("Basic %s", c.apiKey))
 	req.Header.Set("Accept", "application/xml")
-	req.Header.Set("X-Api-Version", "2.13")
+	req.Header.Set("X-Api-Version", "2.15")
 	if req.Method == "POST" || req.Method == "PUT" {
 		req.Header.Set("Content-Type", "application/xml; charset=utf-8")
 	}

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -155,7 +155,8 @@ type NewSubscription struct {
 	StartsAt                NullTime             `xml:"starts_at,omitempty"`
 	TotalBillingCycles      int                  `xml:"total_billing_cycles,omitempty"`
 	RenewalBillingCycles    NullInt              `xml:"renewal_billing_cycles"`
-	FirstRenewalDate        NullTime             `xml:"first_renewal_date,omitempty"`
+	FirstRenewalDate        NullTime             `xml:"first_renewal_date,omitempty"` // Deprecated, use NextBillDate
+	NextBillDate            NullTime             `xml:"next_bill_date,omitempty"`
 	CollectionMethod        string               `xml:"collection_method,omitempty"`
 	AutoRenew               bool                 `xml:"auto_renew,omitempty"`
 	NetTerms                NullInt              `xml:"net_terms,omitempty"`

--- a/subscriptions_test.go
+++ b/subscriptions_test.go
@@ -134,9 +134,9 @@ func TestSubscriptions_NewSubscription_Encoding(t *testing.T) {
 				Account: recurly.Account{
 					Code: "123",
 				},
-				FirstRenewalDate: recurly.NewTime(ts),
+				NextBillDate: recurly.NewTime(ts),
 			},
-			expected: "<subscription><plan_code>gold</plan_code><account><account_code>123</account_code></account><currency>USD</currency><first_renewal_date>2015-06-03T13:42:23Z</first_renewal_date></subscription>",
+			expected: "<subscription><plan_code>gold</plan_code><account><account_code>123</account_code></account><currency>USD</currency><next_bill_date>2015-06-03T13:42:23Z</next_bill_date></subscription>",
 		},
 		{
 			v: recurly.NewSubscription{


### PR DESCRIPTION
There are some new features regarding editing invoices if a feature flag is turned on that I did not make, so this is not a comprehensive update of all changes since 2.13 but it is safe to update. Note that `FirstRenewalDate` is deprecated and should be replaced with `NextBillDate`. 

https://dev.recurly.com/page/api-release-notes#v215-release-notes