### PR TITLE
fix null time marshaling panic error

### DIFF
--- a/type_null_time.go
+++ b/type_null_time.go
@@ -1,6 +1,7 @@
 package recurly
 
 import (
+	"encoding/json"
 	"encoding/xml"
 	"time"
 )
@@ -10,8 +11,8 @@ const DateTimeFormat = "2006-01-02T15:04:05Z07:00"
 
 // NullTime is used for properly handling time.Time types that could be null.
 type NullTime struct {
-	*time.Time
-	Raw string `xml:",innerxml"`
+	*time.Time `json:"time,omitempty"`
+	Raw        string `xml:",innerxml"`
 }
 
 // NewTime generates a new NullTime.
@@ -42,6 +43,10 @@ func (t *NullTime) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	}
 
 	return nil
+}
+
+func (t NullTime) MarshalJSON() ([]byte, error) {
+	return json.Marshal(t.Time)
 }
 
 // MarshalXML marshals times into their proper format. Otherwise nothing is

--- a/type_null_time_test.go
+++ b/type_null_time_test.go
@@ -2,6 +2,7 @@ package recurly
 
 import (
 	"bytes"
+	"encoding/json"
 	"encoding/xml"
 	"fmt"
 	"testing"
@@ -29,6 +30,20 @@ func TestNulTime(t *testing.T) {
 		t.Fatal(diff)
 	} else if diff := cmp.Diff(expected2, given2); diff != "" {
 		t.Fatal(diff)
+	}
+
+	// check marshal interface
+	if bytes, err := json.Marshal(given1); err != nil {
+		t.Fatalf("json marshaling error %s", err.Error())
+	} else {
+		timeBytes, _ := json.Marshal(given1.Time)
+		if diff := cmp.Diff(timeBytes, bytes); diff != "" {
+			t.Fatal(diff)
+		}
+	}
+
+	if _, err := json.Marshal(given3); err != nil {
+		t.Fatalf("json marshaling error %s", err.Error())
 	}
 
 	type s struct {


### PR DESCRIPTION
### Problem:
  embedded time field with interface inheritance results panic when json encoding empty `nulltime`

https://play.golang.org/p/AUjb81NemYc
```
package main

import (
    "encoding/json"
    "time"
)

type embedTest struct {
    *time.Time `json:"time,omitempty"`
    Msg        string `json:"message"`
}

func main() {
    a := embedTest{}
    json.Marshal(a) // bubu, panic ~_~
}
```

