### PR TITLE
fix null time marshaling panic error

### DIFF
--- a/type_null_bool.go
+++ b/type_null_bool.go
@@ -32,7 +32,7 @@ func (n NullBool) MarshalJSON() ([]byte, error) {
 	if n.Valid {
 		return json.Marshal(n.Bool)
 	}
-	return []byte(""), nil
+	return []byte("null"), nil
 }
 
 // UnmarshalXML unmarshals an bool properly, as well as marshaling an empty string to nil.

--- a/type_null_bool.go
+++ b/type_null_bool.go
@@ -1,6 +1,7 @@
 package recurly
 
 import (
+	"encoding/json"
 	"encoding/xml"
 	"strconv"
 )
@@ -24,6 +25,14 @@ func NewBool(b bool) NullBool {
 // Is checks to see if the boolean is valid and equivalent
 func (n NullBool) Is(b bool) bool {
 	return n.Valid && n.Bool == b
+}
+
+// MarshalJSON marshals an bool based on whether valid is true
+func (n NullBool) MarshalJSON() ([]byte, error) {
+	if n.Valid {
+		return json.Marshal(n.Bool)
+	}
+	return []byte(""), nil
 }
 
 // UnmarshalXML unmarshals an bool properly, as well as marshaling an empty string to nil.

--- a/type_null_bool_test.go
+++ b/type_null_bool_test.go
@@ -36,7 +36,7 @@ func TestNullBool(t *testing.T) {
 	}{
 		{v: given0, expected: "true"},
 		{v: given1, expected: "false"},
-		{v: given2, expected: ""},
+		{v: given2, expected: "null"},
 	}
 	for _, tt := range jsontests {
 		bytes, _ := json.Marshal(tt.v)

--- a/type_null_bool_test.go
+++ b/type_null_bool_test.go
@@ -2,6 +2,7 @@ package recurly
 
 import (
 	"bytes"
+	"encoding/json"
 	"encoding/xml"
 	"testing"
 
@@ -27,6 +28,21 @@ func TestNullBool(t *testing.T) {
 		t.Fatalf("unexpected value")
 	} else if given2.Is(false) {
 		t.Fatalf("unexpected value")
+	}
+
+	jsontests := []struct {
+		v        NullBool
+		expected string
+	}{
+		{v: given0, expected: "true"},
+		{v: given1, expected: "false"},
+		{v: given2, expected: ""},
+	}
+	for _, tt := range jsontests {
+		bytes, _ := json.Marshal(tt.v)
+		if diff := cmp.Diff(string(bytes), tt.expected); diff != "" {
+			t.Fatal(diff)
+		}
 	}
 
 	type s struct {

--- a/type_null_int19.go
+++ b/type_null_int19.go
@@ -24,7 +24,7 @@ func (n NullInt) MarshalJSON() ([]byte, error) {
 	if n.Valid {
 		return json.Marshal(n.Int)
 	}
-	return []byte(""), nil
+	return []byte("null"), nil
 }
 
 // UnmarshalXML unmarshals an int properly, as well as marshaling an empty string to nil.

--- a/type_null_int19.go
+++ b/type_null_int19.go
@@ -3,6 +3,7 @@
 package recurly
 
 import (
+	"encoding/json"
 	"encoding/xml"
 	"strings"
 )
@@ -16,6 +17,14 @@ type NullInt struct {
 // NewInt builds a new NullInt struct.
 func NewInt(i int) NullInt {
 	return NullInt{Int: i, Valid: true}
+}
+
+// MarshalJSON marshals an int based on whether valid is true
+func (n NullInt) MarshalJSON() ([]byte, error) {
+	if n.Valid {
+		return json.Marshal(n.Int)
+	}
+	return []byte(""), nil
 }
 
 // UnmarshalXML unmarshals an int properly, as well as marshaling an empty string to nil.

--- a/type_null_int_17.go
+++ b/type_null_int_17.go
@@ -23,7 +23,7 @@ func (n NullInt) MarshalJSON() ([]byte, error) {
 	if n.Valid {
 		return json.Marshal(n.Int)
 	}
-	return []byte(""), nil
+	return []byte("null"), nil
 }
 
 // UnmarshalXML unmarshals an int properly, as well as marshaling an empty string to nil.

--- a/type_null_int_17.go
+++ b/type_null_int_17.go
@@ -2,7 +2,10 @@
 
 package recurly
 
-import "encoding/xml"
+import (
+	"encoding/json"
+	"encoding/xml"
+)
 
 // NullInt is used for properly handling int types that could be null.
 type NullInt struct {
@@ -13,6 +16,14 @@ type NullInt struct {
 // NewInt builds a new NullInt struct.
 func NewInt(i int) NullInt {
 	return NullInt{Int: i, Valid: true}
+}
+
+// MarshalJSON marshals an int based on whether valid is true
+func (n NullInt) MarshalJSON() ([]byte, error) {
+	if n.Valid {
+		return json.Marshal(n.Int)
+	}
+	return []byte(""), nil
 }
 
 // UnmarshalXML unmarshals an int properly, as well as marshaling an empty string to nil.

--- a/type_null_int_test.go
+++ b/type_null_int_test.go
@@ -2,6 +2,7 @@ package recurly
 
 import (
 	"bytes"
+	"encoding/json"
 	"encoding/xml"
 	"testing"
 
@@ -13,6 +14,21 @@ func TestNullInt(t *testing.T) {
 		t.Fatal(diff)
 	} else if diff := cmp.Diff(NewInt(0), NullInt{Int: 0, Valid: true}); diff != "" {
 		t.Fatal(diff)
+	}
+
+	jsontests := []struct {
+		v        NullInt
+		expected string
+	}{
+		{v: NewInt(5), expected: "5"},
+		{v: NewInt(0), expected: "0"},
+		{v: NullInt{}, expected: ""},
+	}
+	for _, tt := range jsontests {
+		bytes, _ := json.Marshal(tt.v)
+		if diff := cmp.Diff(string(bytes), tt.expected); diff != "" {
+			t.Fatal(diff)
+		}
 	}
 
 	type s struct {

--- a/type_null_int_test.go
+++ b/type_null_int_test.go
@@ -22,7 +22,7 @@ func TestNullInt(t *testing.T) {
 	}{
 		{v: NewInt(5), expected: "5"},
 		{v: NewInt(0), expected: "0"},
-		{v: NullInt{}, expected: ""},
+		{v: NullInt{}, expected: "null"},
 	}
 	for _, tt := range jsontests {
 		bytes, _ := json.Marshal(tt.v)

--- a/type_null_time.go
+++ b/type_null_time.go
@@ -48,7 +48,10 @@ func (t *NullTime) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 // MarshalJSON method has to be added here due to embeded interface json marshal issue in Go
 // with panic on nil time field
 func (t NullTime) MarshalJSON() ([]byte, error) {
-	return json.Marshal(t.Time)
+	if t.Time != nil {
+		return json.Marshal(t.Time)
+	}
+	return []byte("null"), nil
 }
 
 // MarshalXML marshals times into their proper format. Otherwise nothing is

--- a/type_null_time.go
+++ b/type_null_time.go
@@ -1,6 +1,7 @@
 package recurly
 
 import (
+	"encoding/json"
 	"encoding/xml"
 	"time"
 )
@@ -10,8 +11,8 @@ const DateTimeFormat = "2006-01-02T15:04:05Z07:00"
 
 // NullTime is used for properly handling time.Time types that could be null.
 type NullTime struct {
-	*time.Time
-	Raw string `xml:",innerxml"`
+	*time.Time `json:"time,omitempty"`
+	Raw        string `xml:",innerxml"`
 }
 
 // NewTime generates a new NullTime.
@@ -42,6 +43,10 @@ func (t *NullTime) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	}
 
 	return nil
+}
+
+func (t NullTime) MarshalJSON() ([]byte, error) {
+	return json.Marshal(t.Time)
 }
 
 // MarshalXML marshals times into their proper format. Otherwise nothing is

--- a/type_null_time.go
+++ b/type_null_time.go
@@ -11,8 +11,8 @@ const DateTimeFormat = "2006-01-02T15:04:05Z07:00"
 
 // NullTime is used for properly handling time.Time types that could be null.
 type NullTime struct {
-	*time.Time `json:"time,omitempty"`
-	Raw        string `xml:",innerxml"`
+	*time.Time
+	Raw string `xml:",innerxml"`
 }
 
 // NewTime generates a new NullTime.

--- a/type_null_time.go
+++ b/type_null_time.go
@@ -45,6 +45,8 @@ func (t *NullTime) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	return nil
 }
 
+// MarshalJSON method has to be added here due to embeded interface json marshal issue in Go
+// with panic on nil time field
 func (t NullTime) MarshalJSON() ([]byte, error) {
 	return json.Marshal(t.Time)
 }

--- a/type_null_time_test.go
+++ b/type_null_time_test.go
@@ -2,6 +2,7 @@ package recurly
 
 import (
 	"bytes"
+	"encoding/json"
 	"encoding/xml"
 	"fmt"
 	"testing"
@@ -29,6 +30,20 @@ func TestNulTime(t *testing.T) {
 		t.Fatal(diff)
 	} else if diff := cmp.Diff(expected2, given2); diff != "" {
 		t.Fatal(diff)
+	}
+
+	// check marshal interface
+	if bytes, err := json.Marshal(given1); err != nil {
+		t.Fatalf("json marshaling error %s", err.Error())
+	} else {
+		timeBytes, _ := json.Marshal(given1.Time)
+		if diff := cmp.Diff(timeBytes, bytes); diff != "" {
+			t.Fatal(diff)
+		}
+	}
+
+	if _, err := json.Marshal(given3); err != nil {
+		t.Fatalf("json marshaling error %s", err.Error())
 	}
 
 	type s struct {

--- a/type_null_time_test.go
+++ b/type_null_time_test.go
@@ -33,17 +33,21 @@ func TestNulTime(t *testing.T) {
 	}
 
 	// check marshal interface
-	if bytes, err := json.Marshal(given1); err != nil {
+	b, err := json.Marshal(given1)
+	if err != nil {
 		t.Fatalf("json marshaling error %s", err.Error())
 	} else {
-		timeBytes, _ := json.Marshal(given1.Time)
-		if diff := cmp.Diff(timeBytes, bytes); diff != "" {
+		tb, _ := json.Marshal(given1.Time)
+		if diff := cmp.Diff(tb, b); diff != "" {
 			t.Fatal(diff)
 		}
 	}
 
-	if _, err := json.Marshal(given3); err != nil {
+	b, err = json.Marshal(given3)
+	if err != nil {
 		t.Fatalf("json marshaling error %s", err.Error())
+	} else if !bytes.Equal(b, []byte("null")) {
+		t.Fatal("null time not marshaled to null")
 	}
 
 	type s struct {

--- a/type_unit_amount.go
+++ b/type_unit_amount.go
@@ -5,19 +5,19 @@ import "encoding/xml"
 // UnitAmount is used in plans where unit amounts are represented in cents
 // in both EUR and USD.
 type UnitAmount struct {
-	USD int `xml:"USD,omitempty" json:"USD,omitempty"`
-	EUR int `xml:"EUR,omitempty" json:"EUR,omitempty"`
-	GBP int `xml:"GBP,omitempty" json:"GBP,omitempty"`
-	CAD int `xml:"CAD,omitempty" json:"CAD,omitempty"`
-	AUD int `xml:"AUD,omitempty" json:"AUD,omitempty"`
+	USD int `xml:"USD,omitempty"`
+	EUR int `xml:"EUR,omitempty"`
+	GBP int `xml:"GBP,omitempty"`
+	CAD int `xml:"CAD,omitempty"`
+	AUD int `xml:"AUD,omitempty"`
 }
 
 type uaAlias struct {
-	USD int `xml:"USD,omitempty" json:"USD,omitempty"`
-	EUR int `xml:"EUR,omitempty" json:"EUR,omitempty"`
-	GBP int `xml:"GBP,omitempty" json:"GBP,omitempty"`
-	CAD int `xml:"CAD,omitempty" json:"CAD,omitempty"`
-	AUD int `xml:"AUD,omitempty" json:"AUD,omitempty"`
+	USD int `xml:"USD,omitempty"`
+	EUR int `xml:"EUR,omitempty"`
+	GBP int `xml:"GBP,omitempty"`
+	CAD int `xml:"CAD,omitempty"`
+	AUD int `xml:"AUD,omitempty"`
 }
 
 // UnmarshalXML unmarshals an int properly, as well as marshaling an empty string to nil.

--- a/type_unit_amount.go
+++ b/type_unit_amount.go
@@ -5,11 +5,11 @@ import "encoding/xml"
 // UnitAmount is used in plans where unit amounts are represented in cents
 // in both EUR and USD.
 type UnitAmount struct {
-	USD int `xml:"USD,omitempty"`
-	EUR int `xml:"EUR,omitempty"`
-	GBP int `xml:"GBP,omitempty"`
-	CAD int `xml:"CAD,omitempty"`
-	AUD int `xml:"AUD,omitempty"`
+	USD int `xml:"USD,omitempty" json:"USD,omitempty"`
+	EUR int `xml:"EUR,omitempty" json:"EUR,omitempty"`
+	GBP int `xml:"GBP,omitempty" json:"GBP,omitempty"`
+	CAD int `xml:"CAD,omitempty" json:"CAD,omitempty"`
+	AUD int `xml:"AUD,omitempty" json:"AUD,omitempty"`
 }
 
 type uaAlias struct {

--- a/type_unit_amount.go
+++ b/type_unit_amount.go
@@ -13,11 +13,11 @@ type UnitAmount struct {
 }
 
 type uaAlias struct {
-	USD int `xml:"USD,omitempty"`
-	EUR int `xml:"EUR,omitempty"`
-	GBP int `xml:"GBP,omitempty"`
-	CAD int `xml:"CAD,omitempty"`
-	AUD int `xml:"AUD,omitempty"`
+	USD int `xml:"USD,omitempty" json:"USD,omitempty"`
+	EUR int `xml:"EUR,omitempty" json:"EUR,omitempty"`
+	GBP int `xml:"GBP,omitempty" json:"GBP,omitempty"`
+	CAD int `xml:"CAD,omitempty" json:"CAD,omitempty"`
+	AUD int `xml:"AUD,omitempty" json:"AUD,omitempty"`
 }
 
 // UnmarshalXML unmarshals an int properly, as well as marshaling an empty string to nil.


### PR DESCRIPTION
### Problem:
  embedded time field with interface inheritance results panic when json encoding empty `nulltime`

https://play.golang.org/p/AUjb81NemYc
```
package main

import (
    "encoding/json"
    "time"
)

type embedTest struct {
    *time.Time `json:"time,omitempty"`
    Msg        string `json:"message"`
}

func main() {
    a := embedTest{}
    json.Marshal(a) // bubu, panic ~_~
}
```