### PR TITLE
Allow gateway_code field on purchase requests

### DIFF
--- a/purchases.go
+++ b/purchases.go
@@ -19,4 +19,5 @@ type Purchase struct {
 	TermsAndConditions    string            `xml:"terms_and_conditions,omitempty"`
 	VATReverseChargeNotes string            `xml:"vat_reverse_charge_notes,omitempty"`
 	ShippingAddressID     int64             `xml:"shipping_address_id,omitempty"`
+	GatewayCode           string            `xml:"gateway_code,omitempty"`
 }

--- a/purchases_test.go
+++ b/purchases_test.go
@@ -27,6 +27,7 @@ func TestPurchases_Purchase_Encoding(t *testing.T) {
 				CustomerNotes:         "Some notes for the customer.",
 				TermsAndConditions:    "Our company terms and conditions.",
 				VATReverseChargeNotes: "Vat reverse charge notes.",
+				GatewayCode:           "test-gateway-code",
 				Account: recurly.Account{
 					Code: "c442b36c-c64f-41d7-b8e1-9c04e7a6ff82",
 					ShippingAddresses: &[]recurly.ShippingAddress{
@@ -86,6 +87,7 @@ func TestPurchases_Purchase_Encoding(t *testing.T) {
 				"<customer_notes>Some notes for the customer.</customer_notes>" +
 				"<terms_and_conditions>Our company terms and conditions.</terms_and_conditions>" +
 				"<vat_reverse_charge_notes>Vat reverse charge notes.</vat_reverse_charge_notes>" +
+				"<gateway_code>test-gateway-code</gateway_code>" +
 				"</purchase>",
 		},
 		{


### PR DESCRIPTION
@cristiangraz 

Adding `gateway_code` to `/v2/purchase` requests to enable gateway routing for purchases.

Note: This field has been present since version 2.13, but the developer docs do not mention it ➡️ https://dev.recurly.com/docs/create-purchase