### PR TITLE
add nil checks for client http response

### DIFF
--- a/subscriptions_service.go
+++ b/subscriptions_service.go
@@ -79,9 +79,14 @@ func (s *subscriptionsImpl) Create(sub NewSubscription) (*Response, *NewSubscrip
 	var dst NewSubscriptionResponse
 	var subscription Subscription
 	resp, err := s.client.do(req, &subscription)
+	if err != nil {
+		return resp, nil, err
+	}
+
 	if subscription.UUID != "" { // If subscription not present, dst.Subscription should be nil
 		dst.Subscription = &subscription
 	}
+
 	if resp.transaction != nil {
 		dst.Transaction = resp.transaction
 	}

--- a/subscriptions_service.go
+++ b/subscriptions_service.go
@@ -80,7 +80,7 @@ func (s *subscriptionsImpl) Create(sub NewSubscription) (*Response, *NewSubscrip
 	var subscription Subscription
 	resp, err := s.client.do(req, &subscription)
 	if err != nil {
-		return resp, nil, err
+		return nil, nil, err
 	}
 
 	if subscription.UUID != "" { // If subscription not present, dst.Subscription should be nil

--- a/transactions_service.go
+++ b/transactions_service.go
@@ -86,7 +86,9 @@ func (s *transactionsImpl) Create(t Transaction) (*Response, *Transaction, error
 
 	var dst Transaction
 	resp, err := s.client.do(req, &dst)
-
+	if err != nil {
+		return resp, nil, err
+	}
 	// If there is an error set the response transaction as the returned transaction
 	// so that the caller has access to TransactionError.
 	if resp.IsError() {

--- a/transactions_service.go
+++ b/transactions_service.go
@@ -87,7 +87,7 @@ func (s *transactionsImpl) Create(t Transaction) (*Response, *Transaction, error
 	var dst Transaction
 	resp, err := s.client.do(req, &dst)
 	if err != nil {
-		return resp, nil, err
+		return nil, nil, err
 	}
 	// If there is an error set the response transaction as the returned transaction
 	// so that the caller has access to TransactionError.


### PR DESCRIPTION
we've found panic cases in our apps that happen on [subscription service](https://github.com/blacklightcms/recurly/blob/master/subscriptions_service.go#L85)
service functions need to check whether `resp` is nil or not before referencing any field in resp. I've double checked all the service code and found these two cases which need nil check