### PR TITLE
Add support for AmazonRegion to Billing

### DIFF
--- a/billing.go
+++ b/billing.go
@@ -52,6 +52,7 @@ type Billing struct {
 
 	// Amazon
 	AmazonAgreementID string `xml:"amazon_billing_agreement_id,omitempty"`
+	AmazonRegion      string `xml:"amazon_region,omitempty"`
 
 	// Bank Account
 	// Note: routing numbers and account numbers may start with zeros, so need
@@ -66,7 +67,7 @@ type Billing struct {
 	Token string `xml:"token_id,omitempty"`
 }
 
-// UnmarshalXML is a customer XML unmarshaler for billing info that supports
+// UnmarshalXML is a custom XML unmarshaler for billing info that supports
 // unmarshaling null fields without errors.
 func (b *Billing) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	var v struct {
@@ -98,6 +99,7 @@ func (b *Billing) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 
 		// Amazon
 		AmazonAgreementID string `xml:"amazon_billing_agreement_id,omitempty"`
+		AmazonRegion      string `xml:"amazon_region,omitempty"`
 
 		// Bank Account
 		// Note: routing numbers and account numbers may start with zeros, so need
@@ -135,6 +137,7 @@ func (b *Billing) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 
 		PaypalAgreementID: v.PaypalAgreementID,
 		AmazonAgreementID: v.AmazonAgreementID,
+		AmazonRegion:      v.AmazonRegion,
 
 		NameOnAccount: v.NameOnAccount,
 		RoutingNumber: v.RoutingNumber,

--- a/client.go
+++ b/client.go
@@ -108,14 +108,14 @@ func (c *Client) newRequest(method string, action string, params Params, body in
 	// identifying bugs or updates needed in the library.
 	// https://github.com/blacklightcms/recurly/issues/41
 	req.Header.Set("User-Agent", fmt.Sprintf(
-		"Blacklight/2018-06-05; Go (%s) [%s-%s]",
+		"Blacklight/2019-02-20; Go (%s) [%s-%s]",
 		runtime.Version(),
 		runtime.GOARCH,
 		runtime.GOOS,
 	))
 	req.Header.Set("Authorization", fmt.Sprintf("Basic %s", c.apiKey))
 	req.Header.Set("Accept", "application/xml")
-	req.Header.Set("X-Api-Version", "2.15")
+	req.Header.Set("X-Api-Version", "2.18")
 	if req.Method == "POST" || req.Method == "PUT" {
 		req.Header.Set("Content-Type", "application/xml; charset=utf-8")
 	}


### PR DESCRIPTION
The `amazon_region` field will be introduced in version `2.18` and this PR will remain on hold until after its release. The scheduled release date for `2.18` is January 29, 2019.

Update (02/20): `v2.18` was released last week (02/14). Releases to add support PHP and Ruby were created yesterday. See below:

PHP:
- https://github.com/recurly/recurly-client-php/releases/tag/2.11.2

Ruby:
- https://github.com/recurly/recurly-client-ruby/releases/tag/2.17.6

Official documentation for `v2.18`:
https://dev.recurly.com/docs/create-an-accounts-billing-info-using-external-token