### PR TITLE
add coupon code to update subscription params

### DIFF
--- a/subscriptions.go
+++ b/subscriptions.go
@@ -180,6 +180,7 @@ type UpdateSubscription struct {
 	XMLName              xml.Name             `xml:"subscription"`
 	Timeframe            string               `xml:"timeframe,omitempty"`
 	PlanCode             string               `xml:"plan_code,omitempty"`
+	CouponCode           string               `xml:"coupon_code,omitempty"`
 	Quantity             int                  `xml:"quantity,omitempty"`
 	UnitAmountInCents    int                  `xml:"unit_amount_in_cents,omitempty"`
 	RenewalBillingCycles NullInt              `xml:"renewal_billing_cycles"`

--- a/subscriptions_test.go
+++ b/subscriptions_test.go
@@ -290,6 +290,10 @@ func TestSubscriptions_UpdateSubscription_Encoding(t *testing.T) {
 			expected: "<subscription><plan_code>new-code</plan_code></subscription>",
 		},
 		{
+			v:        recurly.UpdateSubscription{CouponCode: "coupon-code"},
+			expected: "<subscription><coupon_code>coupon-code</coupon_code></subscription>",
+		},
+		{
 			v:        recurly.UpdateSubscription{Quantity: 14, AutoRenew: true, RenewalBillingCycles: recurly.NullInt{Valid: true, Int: 2}},
 			expected: "<subscription><quantity>14</quantity><renewal_billing_cycles>2</renewal_billing_cycles><auto_renew>true</auto_renew></subscription>",
 		},


### PR DESCRIPTION
According to [recurly documentation](https://dev.recurly.com/docs/update-subscription) we can use coupon_code in subscription update request.