### PR TITLE
target splice repo for tests

### DIFF
--- a/accounts_test.go
+++ b/accounts_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/blacklightcms/recurly"
+	"github.com/splice/recurly"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/add_ons_test.go
+++ b/add_ons_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/blacklightcms/recurly"
+	"github.com/splice/recurly"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/adjustments_test.go
+++ b/adjustments_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/blacklightcms/recurly"
+	"github.com/splice/recurly"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/billing_test.go
+++ b/billing_test.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/blacklightcms/recurly"
+	"github.com/splice/recurly"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/client.go
+++ b/client.go
@@ -106,7 +106,7 @@ func (c *Client) newRequest(method string, action string, params Params, body in
 
 	// Add User-Agent tracking for Recurly statistics and potentially
 	// identifying bugs or updates needed in the library.
-	// https://github.com/blacklightcms/recurly/issues/41
+	// https://github.com/splice/recurly/issues/41
 	req.Header.Set("User-Agent", fmt.Sprintf(
 		"Blacklight/2019-02-20; Go (%s) [%s-%s]",
 		runtime.Version(),

--- a/client_test.go
+++ b/client_test.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 
-	"github.com/blacklightcms/recurly"
+	"github.com/splice/recurly"
 )
 
 var (

--- a/coupons_test.go
+++ b/coupons_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/blacklightcms/recurly"
 	"github.com/google/go-cmp/cmp"
+	"github.com/splice/recurly"
 )
 
 // TestCouponsEncoding ensures structs are encoded to XML properly.
@@ -207,7 +207,7 @@ func TestCoupons_Get(t *testing.T) {
 			t.Fatalf("unexpected method: %s", r.Method)
 		}
 		w.WriteHeader(200)
-		io.WriteString(w, `<?xml version="1.0" encoding="UTF-8"?>             
+		io.WriteString(w, `<?xml version="1.0" encoding="UTF-8"?>
             <coupon href="https://your-subdomain.recurly.com/v2/coupons/special">
              	<redemptions href="https://your-subdomain.recurly.com/v2/coupons/special/redemptions"/>
              	<id type="integer">2151093486799579392</id>

--- a/credit_payments_test.go
+++ b/credit_payments_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/blacklightcms/recurly"
+	"github.com/splice/recurly"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,4 +1,4 @@
-package: github.com/blacklightcms/recurly
+package: github.com/splice/recurly
 testImport:
 - package: github.com/google/go-cmp
   subpackages:

--- a/invoices_test.go
+++ b/invoices_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/blacklightcms/recurly"
+	"github.com/splice/recurly"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/mock/client.go
+++ b/mock/client.go
@@ -3,7 +3,7 @@ package mock
 import (
 	"net/http"
 
-	"github.com/blacklightcms/recurly"
+	"github.com/splice/recurly"
 )
 
 // NewClient returns a new instance of *recury.Client with the

--- a/mock/services.go
+++ b/mock/services.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"time"
 
-	"github.com/blacklightcms/recurly"
+	"github.com/splice/recurly"
 )
 
 var _ recurly.AccountsService = &AccountsService{}

--- a/plans_test.go
+++ b/plans_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/blacklightcms/recurly"
+	"github.com/splice/recurly"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/purchases_test.go
+++ b/purchases_test.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/blacklightcms/recurly"
+	"github.com/splice/recurly"
 )
 
 func TestPurchases_Purchase_Encoding(t *testing.T) {

--- a/redemptions_test.go
+++ b/redemptions_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/blacklightcms/recurly"
+	"github.com/splice/recurly"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/response_test.go
+++ b/response_test.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/blacklightcms/recurly"
+	"github.com/splice/recurly"
 )
 
 func TestResponse_ConvenienceMethods(t *testing.T) {

--- a/shipping_addresses_test.go
+++ b/shipping_addresses_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/blacklightcms/recurly"
+	"github.com/splice/recurly"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/subscriptions_test.go
+++ b/subscriptions_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/blacklightcms/recurly"
+	"github.com/splice/recurly"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/transactions_test.go
+++ b/transactions_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/blacklightcms/recurly"
+	"github.com/splice/recurly"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/webhooks/charge_invoices.go
+++ b/webhooks/charge_invoices.go
@@ -3,7 +3,7 @@ package webhooks
 import (
 	"encoding/xml"
 
-	"github.com/blacklightcms/recurly"
+	"github.com/splice/recurly"
 )
 
 // Charge invoice notifications.

--- a/webhooks/credit_invoices.go
+++ b/webhooks/credit_invoices.go
@@ -3,7 +3,7 @@ package webhooks
 import (
 	"encoding/xml"
 
-	"github.com/blacklightcms/recurly"
+	"github.com/splice/recurly"
 )
 
 // Credit invoice notifications.

--- a/webhooks/credit_payments.go
+++ b/webhooks/credit_payments.go
@@ -3,7 +3,7 @@ package webhooks
 import (
 	"encoding/xml"
 
-	"github.com/blacklightcms/recurly"
+	"github.com/splice/recurly"
 )
 
 // Credit payment notifications.

--- a/webhooks/dunning_events.go
+++ b/webhooks/dunning_events.go
@@ -1,6 +1,6 @@
 package webhooks
 
-import "github.com/blacklightcms/recurly"
+import "github.com/splice/recurly"
 
 // Dunning event constants.
 const (

--- a/webhooks/payments.go
+++ b/webhooks/payments.go
@@ -3,7 +3,7 @@ package webhooks
 import (
 	"encoding/xml"
 
-	"github.com/blacklightcms/recurly"
+	"github.com/splice/recurly"
 )
 
 // Payment notifications.

--- a/webhooks/subscriptions.go
+++ b/webhooks/subscriptions.go
@@ -1,6 +1,6 @@
 package webhooks
 
-import "github.com/blacklightcms/recurly"
+import "github.com/splice/recurly"
 
 // Subscription notifications.
 // https://dev.recurly.com/page/webhooks#subscription-notifications

--- a/webhooks/webhooks_test.go
+++ b/webhooks/webhooks_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/blacklightcms/recurly"
-	"github.com/blacklightcms/recurly/webhooks"
+	"github.com/splice/recurly"
+	"github.com/splice/recurly/webhooks"
 	"github.com/google/go-cmp/cmp"
 )
 


### PR DESCRIPTION
This PR ensures that we test against our repo when running `go test` rather than the upstream repo.