### PR TITLE
Exporting transaction in Response

### DIFF
--- a/client.go
+++ b/client.go
@@ -166,9 +166,9 @@ func (c *Client) do(req *http.Request, v interface{}) (*Response, error) {
 			}
 
 			// If the response object includes a TransactionError, set the
-			// transaction field on the response object and the TransactionError field.
+			// Transaction field on the response object and the TransactionError field.
 			if ve.Transaction != nil {
-				response.transaction = ve.Transaction
+				response.Transaction = ve.Transaction
 			}
 		} else if response.IsClientError() { // Parse possible individual error message
 			var ve struct {

--- a/client_internal_test.go
+++ b/client_internal_test.go
@@ -102,7 +102,7 @@ func TestClient_Errors(t *testing.T) {
 	}
 
 	// Transaction should be nil
-	if resp.transaction != nil {
+	if resp.Transaction != nil {
 		t.Fatal("expected transaction to be nil")
 	}
 
@@ -157,7 +157,7 @@ func TestClient_Error(t *testing.T) {
 	}
 
 	// Transaction should be nil
-	if resp.transaction != nil {
+	if resp.Transaction != nil {
 		t.Fatal("expected transaction to be nil")
 	}
 

--- a/responses.go
+++ b/responses.go
@@ -16,7 +16,7 @@ type Response struct {
 	Errors []Error
 
 	// transaction holds the transaction returned with a transaction error.
-	transaction *Transaction
+	Transaction *Transaction
 }
 
 var (

--- a/subscriptions_service.go
+++ b/subscriptions_service.go
@@ -87,8 +87,8 @@ func (s *subscriptionsImpl) Create(sub NewSubscription) (*Response, *NewSubscrip
 		dst.Subscription = &subscription
 	}
 
-	if resp.transaction != nil {
-		dst.Transaction = resp.transaction
+	if resp.Transaction != nil {
+		dst.Transaction = resp.Transaction
 	}
 
 	return resp, &dst, err

--- a/transactions_service.go
+++ b/transactions_service.go
@@ -92,8 +92,8 @@ func (s *transactionsImpl) Create(t Transaction) (*Response, *Transaction, error
 	// If there is an error set the response transaction as the returned transaction
 	// so that the caller has access to TransactionError.
 	if resp.IsError() {
-		if resp.transaction != nil {
-			dst = *resp.transaction
+		if resp.Transaction != nil {
+			dst = *resp.Transaction
 		}
 	}
 


### PR DESCRIPTION
This pr seeks to address my comment in issue #110 as I am blocked from being able to access [Recurly's Transactions Errors](https://dev.recurly.com/page/transaction-errors) when using the [Create Purchase Endpoint](https://dev.recurly.com/docs/create-purchase)