### PR TITLE
Clarify that AmountInCents is optional for invoice refunds

### DIFF
--- a/invoices_service.go
+++ b/invoices_service.go
@@ -203,7 +203,7 @@ func (s *invoicesImpl) RefundVoidOpenAmount(invoiceNumber int, amountInCents int
 		AmountInCents int      `xml:"amount_in_cents,omitempty"`
 		RefundMethod  string   `xml:"refund_method,omitempty"`
 	}{
-		AmountInCents: amountInCents, // Amount is required
+		AmountInCents: amountInCents, // Amount defaults to remaining refundable amount on the original invoice
 		RefundMethod:  refundMethod,  // Refund method defaults to "credit_first"
 	}
 	req, err := s.client.newRequest("POST", action, nil, data)

--- a/invoices_test.go
+++ b/invoices_test.go
@@ -1072,7 +1072,7 @@ func TestInvoices_MarkFailed(t *testing.T) {
 	}
 }
 
-func TestInvoices_RefundVoidOpenAmount(t *testing.T) {
+func TestInvoices_RefundVoidOpenAmount_NoParams(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -1080,11 +1080,19 @@ func TestInvoices_RefundVoidOpenAmount(t *testing.T) {
 		if r.Method != "POST" {
 			t.Fatalf("unexpected method: %s", r.Method)
 		}
+		b, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer r.Body.Close()
+		if !bytes.Equal(b, []byte("<invoice></invoice>")) {
+			t.Fatalf("unexpected input: %s", string(b))
+		}
 		w.WriteHeader(201)
 		fmt.Fprint(w, `<?xml version="1.0" encoding="UTF-8"?><invoice></invoice>`)
 	})
 
-	resp, _, err := client.Invoices.RefundVoidOpenAmount(1010, 100, "")
+	resp, _, err := client.Invoices.RefundVoidOpenAmount(1010, 0, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	} else if resp.IsError() {


### PR DESCRIPTION
Recurly's [docs](https://dev.recurly.com/docs/open-amount-refunds) don't specify that you must set a `AmountInCents` when refunding/void open amounts on invoices but there is a comment in the library that says that it's required.  

I updated the comment to show the default behavior and added a test to make sure that empty params work.  I did not test the opposite case since there was already a test for refunding/voiding an invoice with `AmountInCents` and `RefundMethod` passed in.