### PR TITLE
set up purchase subscription schema

### DIFF
--- a/purchases.go
+++ b/purchases.go
@@ -5,19 +5,37 @@ import "encoding/xml"
 // Purchase represents an individual checkout holding at least one
 // subscription OR one adjustment
 type Purchase struct {
-	XMLName               xml.Name          `xml:"purchase"`
-	Account               Account           `xml:"account,omitempty"`
-	Adjustments           []Adjustment      `xml:"adjustments>adjustment,omitempty"`
-	CollectionMethod      string            `xml:"collection_method,omitempty"`
-	Currency              string            `xml:"currency"`
-	PONumber              string            `xml:"po_number,omitempty"`
-	NetTerms              NullInt           `xml:"net_terms,omitempty"`
-	GiftCard              string            `xml:"gift_card>redemption_code,omitempty"`
-	CouponCodes           []string          `xml:"coupon_codes>coupon_code,omitempty"`
-	Subscriptions         []NewSubscription `xml:"subscriptions>subscription,omitempty"`
-	CustomerNotes         string            `xml:"customer_notes,omitempty"`
-	TermsAndConditions    string            `xml:"terms_and_conditions,omitempty"`
-	VATReverseChargeNotes string            `xml:"vat_reverse_charge_notes,omitempty"`
-	ShippingAddressID     int64             `xml:"shipping_address_id,omitempty"`
-	GatewayCode           string            `xml:"gateway_code,omitempty"`
+	XMLName               xml.Name               `xml:"purchase"`
+	Account               Account                `xml:"account,omitempty"`
+	Adjustments           []Adjustment           `xml:"adjustments>adjustment,omitempty"`
+	CollectionMethod      string                 `xml:"collection_method,omitempty"`
+	Currency              string                 `xml:"currency"`
+	PONumber              string                 `xml:"po_number,omitempty"`
+	NetTerms              NullInt                `xml:"net_terms,omitempty"`
+	GiftCard              string                 `xml:"gift_card>redemption_code,omitempty"`
+	CouponCodes           []string               `xml:"coupon_codes>coupon_code,omitempty"`
+	Subscriptions         []PurchaseSubscription `xml:"subscriptions>subscription,omitempty"`
+	CustomerNotes         string                 `xml:"customer_notes,omitempty"`
+	TermsAndConditions    string                 `xml:"terms_and_conditions,omitempty"`
+	VATReverseChargeNotes string                 `xml:"vat_reverse_charge_notes,omitempty"`
+	ShippingAddressID     int64                  `xml:"shipping_address_id,omitempty"`
+	GatewayCode           string                 `xml:"gateway_code,omitempty"`
+}
+
+// PurchaseSubscription represents a subscription to purchase
+// some new subscription fields are moved to purchase object level
+// recurly does not accept these fields at subscription level
+type PurchaseSubscription struct {
+	XMLName              xml.Name             `xml:"subscription"`
+	PlanCode             string               `xml:"plan_code"`
+	SubscriptionAddOns   *[]SubscriptionAddOn `xml:"subscription_add_ons>subscription_add_on,omitempty"`
+	UnitAmountInCents    int                  `xml:"unit_amount_in_cents,omitempty"`
+	Quantity             int                  `xml:"quantity,omitempty"`
+	TrialEndsAt          NullTime             `xml:"trial_ends_at,omitempty"`
+	StartsAt             NullTime             `xml:"starts_at,omitempty"`
+	TotalBillingCycles   int                  `xml:"total_billing_cycles,omitempty"`
+	RenewalBillingCycles NullInt              `xml:"renewal_billing_cycles,omitempty"`
+	NextBillDate         NullTime             `xml:"next_bill_date,omitempty"`
+	AutoRenew            bool                 `xml:"auto_renew,omitempty"`
+	CustomFields         *CustomFields        `xml:"custom_fields,omitempty"`
 }

--- a/purchases_test.go
+++ b/purchases_test.go
@@ -63,8 +63,8 @@ func TestPurchases_Purchase_Encoding(t *testing.T) {
 						Description:       "Description of this adjustment",
 					},
 				},
-				Subscriptions: []recurly.NewSubscription{
-					recurly.NewSubscription{PlanCode: "plan1"},
+				Subscriptions: []recurly.PurchaseSubscription{
+					recurly.PurchaseSubscription{PlanCode: "plan1"},
 				},
 				CouponCodes: []string{"coupon1", "coupon2"},
 				GiftCard:    "ABC1234",
@@ -83,7 +83,7 @@ func TestPurchases_Purchase_Encoding(t *testing.T) {
 				"<currency>USD</currency>" +
 				"<gift_card><redemption_code>ABC1234</redemption_code></gift_card>" +
 				"<coupon_codes><coupon_code>coupon1</coupon_code><coupon_code>coupon2</coupon_code></coupon_codes>" +
-				"<subscriptions><subscription><plan_code>plan1</plan_code><account></account><currency></currency></subscription></subscriptions>" +
+				"<subscriptions><subscription><plan_code>plan1</plan_code></subscription></subscriptions>" +
 				"<customer_notes>Some notes for the customer.</customer_notes>" +
 				"<terms_and_conditions>Our company terms and conditions.</terms_and_conditions>" +
 				"<vat_reverse_charge_notes>Vat reverse charge notes.</vat_reverse_charge_notes>" +


### PR DESCRIPTION
we can not simply use `NewSubscription` object in `Subscriptions` array as `Purchase` object already includes some new subscription fields, and Recurly server responds `XML invalid` if we include these fields in subscriptions node. So we need to set up `PurchaseSubscription` specifically for purchase interface.

e.g, if we pass `currency` at subscription level, recurly will respond with:
```
<?xml version="1.0" encoding="UTF-8"?>
<error>
    <symbol>invalid_xml</symbol>
    <description>The provided XML was invalid.</description>
    <details>32:0: ERROR: Element 'currency': This element is not expected.</details>
</error>
```