### PR TITLE
Add `RemainingBillingCycles` to the subscription object

### DIFF
--- a/subscriptions.go
+++ b/subscriptions.go
@@ -184,7 +184,7 @@ type UpdateSubscription struct {
 	CouponCode             string               `xml:"coupon_code,omitempty"`
 	Quantity               int                  `xml:"quantity,omitempty"`
 	UnitAmountInCents      int                  `xml:"unit_amount_in_cents,omitempty"`
-	RenewalBillingCycles   NullInt              `xml:"renewal_billing_cycles"`
+	RenewalBillingCycles   NullInt              `xml:"renewal_billing_cycles,omitempty"`
 	RemainingBillingCycles NullInt              `xml:"remaining_billing_cycles,omitempty"`
 	CollectionMethod       string               `xml:"collection_method,omitempty"`
 	AutoRenew              bool                 `xml:"auto_renew,omitempty"`

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -79,8 +79,8 @@ type Subscription struct {
 	CollectionMethod       string               `xml:"collection_method"`
 	CustomerNotes          string               `xml:"customer_notes,omitempty"`
 	AutoRenew              bool                 `xml:"auto_renew,omitempty"`
-	RenewalBillingCycles   NullInt              `xml:"renewal_billing_cycles"`
-	RemainingBillingCycles NullInt              `xml:"remaining_billing_cycles"`
+	RenewalBillingCycles   NullInt              `xml:"renewal_billing_cycles,omitempty"`
+	RemainingBillingCycles NullInt              `xml:"remaining_billing_cycles,omitempty"`
 	CustomFields           *CustomFields        `xml:"custom_fields,omitempty"`
 }
 

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -80,6 +80,7 @@ type Subscription struct {
 	CustomerNotes          string               `xml:"customer_notes,omitempty"`
 	AutoRenew              bool                 `xml:"auto_renew,omitempty"`
 	RenewalBillingCycles   NullInt              `xml:"renewal_billing_cycles"`
+	RemainingBillingCycles NullInt              `xml:"remaining_billing_cycles"`
 	CustomFields           *CustomFields        `xml:"custom_fields,omitempty"`
 }
 
@@ -177,18 +178,19 @@ type NewSubscriptionResponse struct {
 
 // UpdateSubscription is used to update subscriptions
 type UpdateSubscription struct {
-	XMLName              xml.Name             `xml:"subscription"`
-	Timeframe            string               `xml:"timeframe,omitempty"`
-	PlanCode             string               `xml:"plan_code,omitempty"`
-	CouponCode           string               `xml:"coupon_code,omitempty"`
-	Quantity             int                  `xml:"quantity,omitempty"`
-	UnitAmountInCents    int                  `xml:"unit_amount_in_cents,omitempty"`
-	RenewalBillingCycles NullInt              `xml:"renewal_billing_cycles"`
-	CollectionMethod     string               `xml:"collection_method,omitempty"`
-	AutoRenew            bool                 `xml:"auto_renew,omitempty"`
-	NetTerms             NullInt              `xml:"net_terms,omitempty"`
-	PONumber             string               `xml:"po_number,omitempty"`
-	SubscriptionAddOns   *[]SubscriptionAddOn `xml:"subscription_add_ons>subscription_add_on,omitempty"`
+	XMLName                xml.Name             `xml:"subscription"`
+	Timeframe              string               `xml:"timeframe,omitempty"`
+	PlanCode               string               `xml:"plan_code,omitempty"`
+	CouponCode             string               `xml:"coupon_code,omitempty"`
+	Quantity               int                  `xml:"quantity,omitempty"`
+	UnitAmountInCents      int                  `xml:"unit_amount_in_cents,omitempty"`
+	RenewalBillingCycles   NullInt              `xml:"renewal_billing_cycles"`
+	RemainingBillingCycles NullInt              `xml:"remaining_billing_cycles,omitempty"`
+	CollectionMethod       string               `xml:"collection_method,omitempty"`
+	AutoRenew              bool                 `xml:"auto_renew,omitempty"`
+	NetTerms               NullInt              `xml:"net_terms,omitempty"`
+	PONumber               string               `xml:"po_number,omitempty"`
+	SubscriptionAddOns     *[]SubscriptionAddOn `xml:"subscription_add_ons>subscription_add_on,omitempty"`
 }
 
 // SubscriptionNotes is used to update a subscription's notes.

--- a/subscriptions_test.go
+++ b/subscriptions_test.go
@@ -298,6 +298,10 @@ func TestSubscriptions_UpdateSubscription_Encoding(t *testing.T) {
 			expected: "<subscription><quantity>14</quantity><renewal_billing_cycles>2</renewal_billing_cycles><auto_renew>true</auto_renew></subscription>",
 		},
 		{
+			v:        recurly.UpdateSubscription{RemainingBillingCycles: recurly.NullInt{Valid: true, Int: 0}},
+			expected: "<subscription><remaining_billing_cycles>0</remaining_billing_cycles></subscription>",
+		},
+		{
 			v:        recurly.UpdateSubscription{UnitAmountInCents: 3500},
 			expected: "<subscription><unit_amount_in_cents>3500</unit_amount_in_cents></subscription>",
 		},


### PR DESCRIPTION
Recurly allows updating subscription’s `remaining_billing_cycles` property,  which we need to do for our Recurly subscription cycle management.

This change adds this property to `UpdateSubscription` and `Subscription` structs, which lets us set `remaining_billing_cycles` and validate that it has been set correctly.