### PR TITLE
pagination: allow cursor to be accessed and option for a starting cursor

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -127,7 +127,7 @@ a nil item and nil error will be returned if the item is not found.
 Pagination
 
 All requests for resource collections support pagination. Pagination options are
-described in the recurly.PagerOptions struct and past to the list methods directly.
+described in the recurly.PagerOptions struct and passed to the list methods directly.
 
 	client := recurly.NewClient("your-subdomain", "APIKEY")
 
@@ -157,6 +157,21 @@ You can also let the library paginate for you and return all of the results at o
 	if err := pager.FetchAll(ctx, &accounts); err != nil {
 		return err
 	}
+
+In some cases, you may want to paginate non-consecutively. For example, if you have
+paginated results being sent to a frontend, and the frontend is providing your
+app the next cursor.
+
+In that case you can obtain the next cursor like this (although it may be empty):
+
+	cursor := pager.Cursor()
+
+If you have a cursor, you can provide *PagerOptions with it to start paginating
+the next result set:
+
+	pager := client.Accounts.List(&recurly.PagerOptions{
+		Cursor: cursor,
+	})
 
 */
 package recurly

--- a/mock/pager.go
+++ b/mock/pager.go
@@ -15,6 +15,9 @@ type Pager struct {
 	OnNext      func() bool
 	NextInvoked bool
 
+	OnCursor      func() string
+	CursorInvoked bool
+
 	OnFetch      func(ctx context.Context, dst interface{}) error
 	FetchInvoked bool
 
@@ -30,6 +33,11 @@ func (m *Pager) Count(ctx context.Context) (int, error) {
 func (m *Pager) Next() bool {
 	m.NextInvoked = true
 	return m.OnNext()
+}
+
+func (m *Pager) Cursor() string {
+	m.CursorInvoked = true
+	return m.OnCursor()
 }
 
 func (m *Pager) Fetch(ctx context.Context, dst interface{}) error {

--- a/pager_test.go
+++ b/pager_test.go
@@ -1,0 +1,160 @@
+package recurly_test
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/blacklightcms/recurly"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestPager(t *testing.T) {
+	const CursorA = "1972702718353176814:A1465932489"
+
+	client, s := recurly.NewTestServer()
+	defer s.Close()
+
+	var invocations int
+	s.HandleFunc("GET", "/v2/accounts", func(w http.ResponseWriter, r *http.Request) {
+		cursor := r.URL.Query().Get("cursor")
+		switch invocations {
+		case 0:
+			if cursor != "" {
+				t.Fatalf("unexpected cursor: %s", cursor)
+			}
+			w.Header().Set("Link", `<https://test.recurly.com/v2/accounts?cursor=`+CursorA+`>; rel="next"`)
+		case 1:
+			if cursor != CursorA {
+				t.Fatalf("unexpected cursor: %s", cursor)
+			}
+		default:
+			t.Fatalf("unexpected number of invocations")
+		}
+
+		query := r.URL.Query()
+		query.Del("cursor") // conditionally checked above
+		if diff := cmp.Diff(query, url.Values{
+			"per_page":   []string{"50"},
+			"sort":       []string{"created_at"},
+			"order":      []string{"asc"},
+			"state":      []string{"active"},
+			"begin_time": []string{"2011-10-17T17:24:53Z"},
+			"end_time":   []string{"2011-10-18T17:24:53Z"},
+		}); diff != "" {
+			t.Fatal(diff)
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Write(MustOpenFile("accounts.xml"))
+		invocations++
+	}, t)
+
+	pager := client.Accounts.List(&recurly.PagerOptions{
+		PerPage:   50,
+		Sort:      "created_at",
+		Order:     "asc",
+		State:     "active",
+		BeginTime: recurly.NewTime(MustParseTime("2011-10-17T17:24:53Z")),
+		EndTime:   recurly.NewTime(MustParseTime("2011-10-18T17:24:53Z")),
+	})
+
+	for pager.Next() {
+		var a []recurly.Account
+		if err := pager.Fetch(context.Background(), &a); err != nil {
+			t.Fatal(err)
+		} else if !s.Invoked {
+			t.Fatal("expected s to be invoked")
+		} else if diff := cmp.Diff(a, []recurly.Account{*NewTestAccount()}); diff != "" {
+			t.Fatal(diff)
+		}
+
+		// Check cursor.
+		switch invocations {
+		case 1:
+			if pager.Cursor() == CursorA {
+				break
+			}
+			fallthrough
+		case 2:
+			if pager.Cursor() == "" {
+				break
+			}
+			fallthrough
+		default:
+			t.Fatalf("unexpected cursors on invocation %d: cursor=%s", invocations, pager.Cursor())
+		}
+
+		s.Invoked = false
+	}
+}
+
+// Verify pager can accept a cursor and send it through to Recurly as expected.
+func TestPager_CursorProvided(t *testing.T) {
+	const CursorA = "CURSOR_A"
+	const CursorB = "CURSOR_B"
+
+	client, s := recurly.NewTestServer()
+	defer s.Close()
+
+	var invocations int
+	s.HandleFunc("GET", "/v2/accounts", func(w http.ResponseWriter, r *http.Request) {
+		cursor := r.URL.Query().Get("cursor")
+		switch invocations {
+		case 0:
+			if cursor != CursorA {
+				t.Fatalf("unexpected cursor: %s", cursor)
+			}
+			w.Header().Set("Link", `<https://test.recurly.com/v2/accounts?cursor=`+CursorB+`>; rel="next"`)
+		case 1:
+			if cursor != CursorB {
+				t.Fatalf("unexpected cursor: %s", cursor)
+			}
+		default:
+			t.Fatalf("unexpected number of invocations")
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Write(MustOpenFile("accounts.xml"))
+		invocations++
+	}, t)
+
+	pager := client.Accounts.List(&recurly.PagerOptions{
+		Cursor: CursorA, // Provide starting cursor
+	})
+
+	// Verify starting cursor is set.
+	if pager.Cursor() != CursorA {
+		t.Fatalf("unexpected next cursor: %s", pager.Cursor())
+	}
+
+	for pager.Next() {
+		var a []recurly.Account
+		if err := pager.Fetch(context.Background(), &a); err != nil {
+			t.Fatal(err)
+		} else if !s.Invoked {
+			t.Fatal("expected s to be invoked")
+		} else if diff := cmp.Diff(a, []recurly.Account{*NewTestAccount()}); diff != "" {
+			t.Fatal(diff)
+		}
+
+		// Check cursor.
+		switch invocations {
+		case 1:
+			if pager.Cursor() == CursorB {
+				break
+			}
+			fallthrough
+		case 2:
+			if pager.Cursor() == "" {
+				break
+			}
+			fallthrough
+		default:
+			t.Fatalf("unexpected cursors on invocation %d: cursor=%s", invocations, pager.Cursor())
+		}
+
+		s.Invoked = false
+	}
+}


### PR DESCRIPTION
`v.1.0.0` simplified pagination, but in the process hid the next cursor from the library user. @kmikiy shared a use case in #120 where frontend pagination was no longer possible without having access to the cursor and without being able to set a starting cursor.

This PR addresses that by adding a new `Cursor() string` method to the `Pager` interface so that the next cursor is accessible.

The `cursor` field on `PagerOptions` is now exported as `Cursor` so that users can set a starting cursor when paginating.

Closes #120.