### PR TITLE
Support for API v2.22

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
  Recurly is a Go (golang) API Client for the [Recurly](https://recurly.com/) API. It is actively maintained, unit tested, and uses no external dependencies. The vast majority of the API is implemented.
 
  Supports:
-  - Recurly API `v2.21`
+  - Recurly API `v2.22`
   - Accounts
   - Add Ons
   - Adjustments

--- a/accounts.go
+++ b/accounts.go
@@ -94,7 +94,7 @@ type Account struct {
 	HasPastDueInvoice       NullBool           `xml:"has_past_due_invoice,omitempty"`
 	PreferredLocale         string             `xml:"preferred_locale,omitempty"`
 	CustomFields            *CustomFields      `xml:"custom_fields,omitempty"`
-	TransactionType         string             `xml:"transaction_type,omitempty"`
+	TransactionType         string             `xml:"transaction_type,omitempty"` // Create only
 }
 
 // AccountBalance is used for getting the account balance.

--- a/accounts.go
+++ b/accounts.go
@@ -94,6 +94,7 @@ type Account struct {
 	HasPastDueInvoice       NullBool           `xml:"has_past_due_invoice,omitempty"`
 	PreferredLocale         string             `xml:"preferred_locale,omitempty"`
 	CustomFields            *CustomFields      `xml:"custom_fields,omitempty"`
+	TransactionType         string             `xml:"transaction_type,omitempty"`
 }
 
 // AccountBalance is used for getting the account balance.

--- a/accounts_test.go
+++ b/accounts_test.go
@@ -121,6 +121,14 @@ func TestAccounts_Encoding(t *testing.T) {
 			`),
 		},
 		{
+			v: recurly.Account{TransactionType: "moto"},
+			expected: MustCompactString(`
+				<account>
+					<transaction_type>moto</transaction_type>
+				</account>
+			`),
+		},
+		{
 			v: recurly.Account{FirstName: "Larry", Address: &recurly.Address{Address: "123 Main St.", City: "San Francisco", State: "CA", Zip: "94105", Country: "US"}},
 			expected: MustCompactString(`
 				<account>

--- a/billing.go
+++ b/billing.go
@@ -104,6 +104,7 @@ type Billing struct {
 	Currency                        string `xml:"currency,omitempty"`                              // Create/update only
 	Token                           string `xml:"token_id,omitempty"`                              // Create/update only
 	ThreeDSecureActionResultTokenID string `xml:"three_d_secure_action_result_token_id,omitempty"` // Create/update only
+	TransactionType                 string `xml:"transaction_type,omitempty"`                      // Create only
 }
 
 // Type returns the billing info type. Returns either  "", "bank", or an empty string.

--- a/billing_test.go
+++ b/billing_test.go
@@ -139,7 +139,7 @@ func TestBilling_Encoding(t *testing.T) {
 			v: recurly.Billing{TransactionType: "moto"},
 			expected: MustCompactString(`
 				<billing_info>
-					<transaction_type>motot</transaction_type>
+					<transaction_type>moto</transaction_type>
 				</billing_info>
 			`),
 		},

--- a/billing_test.go
+++ b/billing_test.go
@@ -135,6 +135,14 @@ func TestBilling_Encoding(t *testing.T) {
 				</billing_info>
 			`),
 		},
+		{
+			v: recurly.Billing{TransactionType: "moto"},
+			expected: MustCompactString(`
+				<billing_info>
+					<transaction_type>motot</transaction_type>
+				</billing_info>
+			`),
+		},
 	}
 
 	for i, tt := range tests {

--- a/invoices.go
+++ b/invoices.go
@@ -344,6 +344,7 @@ type InvoiceRefund struct {
 type CollectInvoice struct {
 	XMLName         xml.Name `xml:"invoice"`
 	TransactionType string   `xml:"transaction_type,omitempty"` // Optional transaction type. Currently accepts "moto"
+	BillingInfo     *Billing `xml:"billing_info,omitempty"`
 }
 
 // InvoiceLineItemsRefund is used to refund one or more line items on an invoice.

--- a/invoices.go
+++ b/invoices.go
@@ -149,7 +149,7 @@ const (
 	VoidRefundMethodCreditFirst      = "credit_first"
 )
 
-// Invoice is an individual invoice for an account. Transactions aareer guaranteed
+// Invoice is an individual invoice for an account. Transactions are guaranteed
 // to be sorted from oldest to newest by date.
 // The only fields annotated with XML tags are those for posting an invoice.
 // Unmarshaling an invoice is handled by the custom UnmarshalXML function.

--- a/invoices.go
+++ b/invoices.go
@@ -51,7 +51,7 @@ type InvoicesService interface {
 	// is rate limited. See Recurly's documentation for details.
 	//
 	// https://dev.recurly.com/docs/collect-an-invoice
-	Collect(ctx context.Context, invoiceNumber int) (*Invoice, error)
+	Collect(ctx context.Context, invoiceNumber int, collectInvoice CollectInvoice) (*Invoice, error)
 
 	// MarkPaid marks an invoice as paid successfully.
 	//
@@ -340,6 +340,12 @@ type InvoiceRefund struct {
 	RefundedAt          NullTime `xml:"refunded_at,omitempty"`
 }
 
+// CollectInvoice is used as the request body for collecting an invoice.
+type CollectInvoice struct {
+	XMLName         xml.Name `xml:"invoice"`
+	TransactionType string   `xml:"transaction_type,omitempty"` // Optional transaction type. Currently accepts "moto"
+}
+
 // InvoiceLineItemsRefund is used to refund one or more line items on an invoice.
 type InvoiceLineItemsRefund struct {
 	XMLName   xml.Name       `xml:"invoice"`
@@ -440,9 +446,9 @@ func (s *invoicesImpl) Create(ctx context.Context, accountCode string, invoice I
 	return dst.ChargeInvoice, nil
 }
 
-func (s *invoicesImpl) Collect(ctx context.Context, invoiceNumber int) (*Invoice, error) {
+func (s *invoicesImpl) Collect(ctx context.Context, invoiceNumber int, collectInvoice CollectInvoice) (*Invoice, error) {
 	path := fmt.Sprintf("/invoices/%d/collect", invoiceNumber)
-	req, err := s.client.newRequest("PUT", path, nil)
+	req, err := s.client.newRequest("PUT", path, collectInvoice)
 	if err != nil {
 		return nil, err
 	}

--- a/mock/invoices.go
+++ b/mock/invoices.go
@@ -29,7 +29,7 @@ type InvoicesService struct {
 	OnCreate      func(ctx context.Context, accountCode string, invoice recurly.Invoice) (*recurly.Invoice, error)
 	CreateInvoked bool
 
-	OnCollect      func(ctx context.Context, invoiceNumber int) (*recurly.Invoice, error)
+	OnCollect      func(ctx context.Context, invoiceNumber int, collectInvoice recurly.CollectInvoice) (*recurly.Invoice, error)
 	CollectInvoked bool
 
 	OnMarkPaid      func(ctx context.Context, invoiceNumber int) (*recurly.Invoice, error)
@@ -81,9 +81,9 @@ func (m *InvoicesService) Create(ctx context.Context, accountCode string, invoic
 	return m.OnCreate(ctx, accountCode, invoice)
 }
 
-func (m *InvoicesService) Collect(ctx context.Context, invoiceNumber int) (*recurly.Invoice, error) {
+func (m *InvoicesService) Collect(ctx context.Context, invoiceNumber int, collectInvoice recurly.CollectInvoice) (*recurly.Invoice, error) {
 	m.CollectInvoked = true
-	return m.OnCollect(ctx, invoiceNumber)
+	return m.OnCollect(ctx, invoiceNumber, collectInvoice)
 }
 
 func (m *InvoicesService) MarkPaid(ctx context.Context, invoiceNumber int) (*recurly.Invoice, error) {

--- a/purchases.go
+++ b/purchases.go
@@ -67,7 +67,7 @@ type Purchase struct {
 	ShippingAddressID     int64                  `xml:"shipping_address_id,omitempty"`
 	GatewayCode           string                 `xml:"gateway_code,omitempty"`
 	ShippingFees          *[]ShippingFee         `xml:"shipping_fees>shipping_fee,omitempty"`
-	TransactionType       string                 `xml:"transaction_type,omitempty"`
+	TransactionType       string                 `xml:"transaction_type,omitempty"` // Create only
 }
 
 // PurchaseSubscription represents a subscription to purchase some new subscription.

--- a/purchases.go
+++ b/purchases.go
@@ -67,6 +67,7 @@ type Purchase struct {
 	ShippingAddressID     int64                  `xml:"shipping_address_id,omitempty"`
 	GatewayCode           string                 `xml:"gateway_code,omitempty"`
 	ShippingFees          *[]ShippingFee         `xml:"shipping_fees>shipping_fee,omitempty"`
+	TransactionType       string                 `xml:"transaction_type,omitempty"`
 }
 
 // PurchaseSubscription represents a subscription to purchase some new subscription.

--- a/purchases_test.go
+++ b/purchases_test.go
@@ -61,6 +61,7 @@ func TestPurchases_Purchase_Encoding(t *testing.T) {
 					},
 				},
 				ShippingAddressID: 1,
+				TransactionType:   "moto",
 			},
 			expected: MustCompactString(`
 				<purchase>
@@ -81,6 +82,7 @@ func TestPurchases_Purchase_Encoding(t *testing.T) {
 							<shipping_amount_in_cents>10</shipping_amount_in_cents>
 						</shipping_fee>
 					</shipping_fees>
+					<transaction_type>moto</transaction_type>
 				</purchase>
 			`),
 		},

--- a/recurly.go
+++ b/recurly.go
@@ -19,7 +19,7 @@ import (
 // apiVersion is the API version in use by this client.
 // NOTE: v2.19:
 //		- Parent/child accounts not yet implemented.
-const apiVersion = "2.21"
+const apiVersion = "2.22"
 
 // uaVersion is the userAgent version sent to Recurly so they can track usage
 // of this library.

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -188,6 +188,7 @@ type NewSubscription struct {
 	ShippingMethodCode      string               `xml:"shipping_method_code,omitempty"`
 	ShippingAmountInCents   NullInt              `xml:"shipping_amount_in_cents,omitempty"`
 	CustomFields            *CustomFields        `xml:"custom_fields,omitempty"`
+	TransactionType         string               `xml:"transaction_type,omitempty"` // Optional transaction type. Currently accepts "moto"
 }
 
 // UnmarshalXML unmarshals transactions and handles intermediary state during unmarshaling
@@ -255,6 +256,7 @@ type UpdateSubscription struct {
 	AutoRenew              NullBool             `xml:"auto_renew,omitempty"`
 	CustomFields           *CustomFields        `xml:"custom_fields,omitempty"`
 	BillingInfo            *Billing             `xml:"billing_info,omitempty"`
+	TransactionType        string               `xml:"transaction_type,omitempty"` // Optional transaction type. Currently accepts "moto"
 }
 
 // SubscriptionNotes is used to update a subscription's notes.

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -254,6 +254,7 @@ type UpdateSubscription struct {
 	RenewalBillingCycles   NullInt              `xml:"renewal_billing_cycles,omitempty"`
 	AutoRenew              NullBool             `xml:"auto_renew,omitempty"`
 	CustomFields           *CustomFields        `xml:"custom_fields,omitempty"`
+	BillingInfo            *Billing             `xml:"billing_info,omitempty"`
 }
 
 // SubscriptionNotes is used to update a subscription's notes.

--- a/subscriptions_test.go
+++ b/subscriptions_test.go
@@ -463,6 +463,26 @@ func TestSubscriptions_NewSubscription_Encoding(t *testing.T) {
 				</subscription>
 			`),
 		},
+		{
+			v: recurly.NewSubscription{
+				PlanCode: "gold",
+				Currency: "USD",
+				Account: recurly.Account{
+					Code: "123",
+				},
+				TransactionType: "moto",
+			},
+			expected: MustCompactString(`
+				<subscription>
+					<plan_code>gold</plan_code>
+					<account>
+						<account_code>123</account_code>
+					</account>
+					<currency>USD</currency>
+					<transaction_type>moto</transaction_type>
+				</subscription>
+			`),
+		},
 	}
 
 	for i, tt := range tests {
@@ -599,6 +619,16 @@ func TestSubscriptions_UpdateSubscription_Encoding(t *testing.T) {
 							<quantity>2</quantity>
 						</subscription_add_on>
 					</subscription_add_ons>
+				</subscription>
+			`),
+		},
+		{
+			v: recurly.UpdateSubscription{
+				TransactionType: "moto",
+			},
+			expected: MustCompactString(`
+				<subscription>
+					<transaction_type>moto</transaction_type>
 				</subscription>
 			`),
 		},


### PR DESCRIPTION
This PR adds support for API [v2.22](https://dev.recurly.com/page/api-release-notes#v222-release-notes)

## Changes

- Changes `apiVersion` to `"v2.22"` in recurly.go
- Adds `TransactionType string` property to `Account` struct + unit test for encoding
- Adds `TransactionType string` property to `Billing` struct + unit test for encoding
- Adds `TransactionType string` property to `Purchase` struct + unit test for encoding
- Adds `TransactionType string` property to `NewSubscription` struct + unit test for encoding
- Adds `TransactionType string` property to `UpdateSubscription` struct + unit test for encoding
- Fixes a typo in a comment in invoices.go
- Adds `CollectInvoice` struct to invoices.go
- Changes the method signature of the `InvoicesService.Collect(ctx context.Context, invoiceNumber int) (*Invoice, error)` method to `InvoicesService.Collect(ctx context.Context, invoiceNumber int, collectInvoice CollectInvoice) (*Invoice, error)`
- Updates `InvoicesService.Collect(...)` to use the new parameter
- Adds `BillingInfo *Billing` property to `CollectInvoice` ([doc](https://dev.recurly.com/v2.22/docs/enter-an-offline-payment-for-a-manual-invoice))
- Adds `BillingInfo *Billing` property to  `UpdateSubscription` ([doc](https://dev.recurly.com/v2.22/docs/update-subscription))
- Updates README.md

## Notes

- This is a breaking change because the signature of the InvoicesService.Collect has been changed.
- The billingInfo changes aren't documented in the release notes but they are visible in each individual API endpoint if you look at the [docs](https://dev.recurly.com/v2.22/docs/).
- The XMLName value for the new `CollectInvoice` struct was taken from the official [recurly](https://github.com/recurly/recurly-client-net/commit/071a9a9505e037a1ccde3fffe81a40b0373a64b7#diff-c85c7b6ab55e17f8658dec7f20dbc87bR660) .NET library
- I am not 100% sure about the naming conventions so `CollectInvoice` and the signature of `Collect(...)` are up for debate
- `BillingInfo *Billing` was not added to  the gift card service because this library doesn't implement/support that