### PR TITLE
Add original transaction field to transaction

### DIFF
--- a/testdata/transaction_refunded.xml
+++ b/testdata/transaction_refunded.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<transaction href="https://your-subdomain.recurly.com/v2/transactions/5346552e216a445f82b524bb9d1d27aa" type="credit_card">
+   <account href="https://your-subdomain.recurly.com/v2/accounts/1" />
+   <invoice href="https://your-subdomain.recurly.com/v2/invoices/1108" />
+   <original_transaction href="https://your-subdomain.recurly.com/v2/transactions/b9d02bfaa8bf401abf2b18db76863ac4"/>
+   <uuid>5346552e216a445f82b524bb9d1d27aa</uuid>
+   <action>refund</action>
+   <amount_in_cents type="integer">1000</amount_in_cents>
+   <tax_in_cents type="integer">0</tax_in_cents>
+   <currency>USD</currency>
+   <status>success</status>
+   <description>Order #717</description>
+   <payment_method>credit_card</payment_method>
+   <reference>5416477</reference>
+   <source>transaction</source>
+   <recurring type="boolean">false</recurring>
+   <test type="boolean">true</test>
+   <voidable type="boolean">false</voidable>
+   <refundable type="boolean">false</refundable>
+   <ip_address>127.0.0.1</ip_address>
+   <created_at type="datetime">2015-06-10T15:25:06Z</created_at>
+   <collected_at type="datetime">2015-06-10T15:25:06Z</collected_at>
+   <updated_at type="datetime">2015-06-10T15:25:06Z</updated_at>
+   <details>
+      <account>
+         <account_code>1</account_code>
+         <first_name>Verena</first_name>
+         <last_name>Example</last_name>
+         <company nil="nil" />
+         <email>verena@test.com</email>
+         <billing_info type="credit_card">
+            <first_name>Verena</first_name>
+            <last_name>Example</last_name>
+            <address1>123 Main St.</address1>
+            <address2 nil="nil" />
+            <city>San Francisco</city>
+            <state>CA</state>
+            <zip>94105</zip>
+            <country>US</country>
+            <phone nil="nil" />
+            <vat_number nil="nil" />
+            <card_type>Visa</card_type>
+            <year type="integer">2017</year>
+            <month type="integer">11</month>
+            <first_six>411111</first_six>
+            <last_four>1111</last_four>
+         </billing_info>
+      </account>
+   </details>
+</transaction>

--- a/transactions.go
+++ b/transactions.go
@@ -41,34 +41,35 @@ const (
 
 // Transaction is an individual transaction.
 type Transaction struct {
-	InvoiceNumber    int               // Read only
-	UUID             string            `xml:"uuid,omitempty"` // Read only
-	Action           string            `xml:"action,omitempty"`
-	AmountInCents    int               `xml:"amount_in_cents"`
-	TaxInCents       int               `xml:"tax_in_cents,omitempty"`
-	Currency         string            `xml:"currency"`
-	Status           string            `xml:"status,omitempty"`
-	Description      string            `xml:"description,omitempty"`
-	ProductCode      string            `xml:"-"` // Write only field, saved on the invoice line item but not the transaction
-	PaymentMethod    string            `xml:"payment_method,omitempty"`
-	Reference        string            `xml:"reference,omitempty"`
-	Source           string            `xml:"source,omitempty"`
-	Recurring        NullBool          `xml:"recurring,omitempty"`
-	Test             bool              `xml:"test,omitempty"`
-	Voidable         NullBool          `xml:"voidable,omitempty"`
-	Refundable       NullBool          `xml:"refundable,omitempty"`
-	IPAddress        net.IP            `xml:"ip_address,omitempty"`
-	TransactionError *TransactionError `xml:"transaction_error,omitempty"` // Read only
-	CVVResult        CVVResult         `xml:"cvv_result,omitempty"`        // Read only
-	AVSResult        AVSResult         `xml:"avs_result,omitempty"`        // Read only
-	AVSResultStreet  string            `xml:"avs_result_street,omitempty"` // Read only
-	AVSResultPostal  string            `xml:"avs_result_postal,omitempty"` // Read only
-	CreatedAt        NullTime          `xml:"created_at,omitempty"`        // Read only
-	Account          Account           `xml:"details>account"`             // Read only
-	GatewayType      string            `xml:"gateway_type,omitempty"`      // Read only
-	Origin           string            `xml:"origin,omitempty"`            // Read only
-	Message          string            `xml:"message,omitempty"`           // Read only
-	ApprovalCode     string            `xml:"approval_code,omitempty"`     // Read only
+	InvoiceNumber           int               // Read only
+	OriginalTransactionUUID string            // Read only
+	UUID                    string            `xml:"uuid,omitempty"` // Read only
+	Action                  string            `xml:"action,omitempty"`
+	AmountInCents           int               `xml:"amount_in_cents"`
+	TaxInCents              int               `xml:"tax_in_cents,omitempty"`
+	Currency                string            `xml:"currency"`
+	Status                  string            `xml:"status,omitempty"`
+	Description             string            `xml:"description,omitempty"`
+	ProductCode             string            `xml:"-"` // Write only field, saved on the invoice line item but not the transaction
+	PaymentMethod           string            `xml:"payment_method,omitempty"`
+	Reference               string            `xml:"reference,omitempty"`
+	Source                  string            `xml:"source,omitempty"`
+	Recurring               NullBool          `xml:"recurring,omitempty"`
+	Test                    bool              `xml:"test,omitempty"`
+	Voidable                NullBool          `xml:"voidable,omitempty"`
+	Refundable              NullBool          `xml:"refundable,omitempty"`
+	IPAddress               net.IP            `xml:"ip_address,omitempty"`
+	TransactionError        *TransactionError `xml:"transaction_error,omitempty"` // Read only
+	CVVResult               CVVResult         `xml:"cvv_result,omitempty"`        // Read only
+	AVSResult               AVSResult         `xml:"avs_result,omitempty"`        // Read only
+	AVSResultStreet         string            `xml:"avs_result_street,omitempty"` // Read only
+	AVSResultPostal         string            `xml:"avs_result_postal,omitempty"` // Read only
+	CreatedAt               NullTime          `xml:"created_at,omitempty"`        // Read only
+	Account                 Account           `xml:"details>account"`             // Read only
+	GatewayType             string            `xml:"gateway_type,omitempty"`      // Read only
+	Origin                  string            `xml:"origin,omitempty"`            // Read only
+	Message                 string            `xml:"message,omitempty"`           // Read only
+	ApprovalCode            string            `xml:"approval_code,omitempty"`     // Read only
 
 }
 
@@ -92,15 +93,18 @@ func (t *Transaction) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error
 	type transactionAlias Transaction
 	var v struct {
 		transactionAlias
-		XMLName       xml.Name `xml:"transaction"`
-		InvoiceNumber href     `xml:"invoice"`
+		XMLName                 xml.Name `xml:"transaction"`
+		InvoiceNumber           href     `xml:"invoice"`
+		OriginalTransactionUUID href     `xml:"original_transaction"`
 	}
 	if err := d.DecodeElement(&v, &start); err != nil {
 		return err
 	}
 
 	*t = Transaction(v.transactionAlias)
+
 	t.InvoiceNumber, _ = strconv.Atoi(v.InvoiceNumber.LastPartOfPath())
+	t.OriginalTransactionUUID = v.OriginalTransactionUUID.LastPartOfPath()
 	return nil
 }
 

--- a/transactions_test.go
+++ b/transactions_test.go
@@ -224,3 +224,39 @@ func NewTestTransactionFailed() *recurly.Transaction {
 		},
 	}
 }
+
+// Returns a Transaction corresponding to testdata/transaction_refunded.xml
+// as well as the transaction portion of testdata/errors_transaction_refunded.xml.
+func NewTestTransactionRefunded() *recurly.Transaction {
+	return &recurly.Transaction{
+		InvoiceNumber: 1108,
+		UUID:          "5346552e216a445f82b524bb9d1d27aa", // UUID has been sanitized
+		Action:        "refund",
+		AmountInCents: 1000,
+		TaxInCents:    0,
+		Currency:      "USD",
+		Status:        "success",
+		Description:   "Order #717",
+		PaymentMethod: "credit_card",
+		Reference:     "5416477",
+		Source:        "transaction",
+		Recurring:     recurly.NewBool(false),
+		Test:          true,
+		Voidable:      recurly.NewBool(false),
+		Refundable:    recurly.NewBool(false),
+		IPAddress:     net.ParseIP("127.0.0.1"),
+		Account: recurly.Account{
+			XMLName: xml.Name{Local: "account"},
+			Code:    "1",
+			Email:   "verena@example.com",
+			BillingInfo: &recurly.Billing{
+				XMLName:  xml.Name{Local: "billing_info"},
+				CardType: "Visa",
+				Year:     2015,
+				Month:    11,
+				FirstSix: "400000",
+				LastFour: "0101",
+			},
+		},
+	}
+}


### PR DESCRIPTION
Refund transactions contain a field called: `<original_transaction href="">`, which links to the original debit transaction.
This PR adds a `OriginalTransactionUUID` field to the `Transaction` struct.

`OriginalTransactionUUID` field value is an empty string for transactions that do not have an `<original_transaction>` field.

