### PR TITLE
fix del redemption method signature

### DIFF
--- a/mock/redemptions.go
+++ b/mock/redemptions.go
@@ -22,7 +22,7 @@ type RedemptionsService struct {
 	OnRedeem      func(ctx context.Context, code string, r recurly.CouponRedemption) (*recurly.Redemption, error)
 	RedeemInvoked bool
 
-	OnDelete      func(ctx context.Context, accountCode, couponCode string) error
+	OnDelete      func(ctx context.Context, accountCode, redemptionUUID string) error
 	DeleteInvoked bool
 }
 
@@ -46,7 +46,7 @@ func (m *RedemptionsService) Redeem(ctx context.Context, code string, r recurly.
 	return m.OnRedeem(ctx, code, r)
 }
 
-func (m *RedemptionsService) Delete(ctx context.Context, accountCode, couponCode string) error {
+func (m *RedemptionsService) Delete(ctx context.Context, accountCode, redemptionUUID string) error {
 	m.DeleteInvoked = true
-	return m.OnDelete(ctx, accountCode, couponCode)
+	return m.OnDelete(ctx, accountCode, redemptionUUID)
 }

--- a/redemptions.go
+++ b/redemptions.go
@@ -148,8 +148,8 @@ func (s *redemptionsImpl) Redeem(ctx context.Context, code string, r CouponRedem
 	return &dst, nil
 }
 
-func (s *redemptionsImpl) Delete(ctx context.Context, accountCode, couponCode string) error {
-	path := fmt.Sprintf("/accounts/%s/redemptions/%s", accountCode, couponCode)
+func (s *redemptionsImpl) Delete(ctx context.Context, accountCode, redemptionUUID string) error {
+	path := fmt.Sprintf("/accounts/%s/redemptions/%s", accountCode, redemptionUUID)
 	req, err := s.client.newRequest("DELETE", path, nil)
 	if err != nil {
 		return err

--- a/redemptions.go
+++ b/redemptions.go
@@ -43,7 +43,7 @@ type RedemptionsService interface {
 	// of the coupon. See Recurly's documentation for details.
 	//
 	// https://dev.recurly.com/docs/remove-a-coupon-from-an-account
-	Delete(ctx context.Context, accountCode, couponCode string) error
+	Delete(ctx context.Context, accountCode, redemptionUUID string) error
 }
 
 // Redemptions constants.

--- a/redemptions_test.go
+++ b/redemptions_test.go
@@ -156,11 +156,11 @@ func TestRedemptions_Delete(t *testing.T) {
 	client, s := recurly.NewTestServer()
 	defer s.Close()
 
-	s.HandleFunc("DELETE", "/v2/accounts/1/redemptions/30_off", func(w http.ResponseWriter, r *http.Request) {
+	s.HandleFunc("DELETE", "/v2/accounts/1/redemptions/3223", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 	}, t)
 
-	if err := client.Redemptions.Delete(context.Background(), "1", "30_off"); !s.Invoked {
+	if err := client.Redemptions.Delete(context.Background(), "1", "3223"); !s.Invoked {
 		t.Fatal("expected fn invocation")
 	} else if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
recurly doc for [delete redemption](https://dev.recurly.com/docs/remove-a-coupon-from-an-account) is wrong, I've confirmed and tested, we need to pass redemption uuid instead of coupon code in the url. they will soon update the misleading wrong doc.