### PR TITLE
Marshal Origin for Adjustments

### DIFF
--- a/adjustments.go
+++ b/adjustments.go
@@ -103,6 +103,7 @@ func (a Adjustment) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 		AccountingCode      string   `xml:"accounting_code,omitempty"`
 		RevenueScheduleType string   `xml:"revenue_schedule_type,omitempty"`
 		ProductCode         string   `xml:"product_code,omitempty"`
+		Origin              string   `xml:"origin,omitempty"`
 		UnitAmountInCents   NullInt  `xml:"unit_amount_in_cents,omitempty"`
 		Quantity            int      `xml:"quantity,omitempty"`
 		Currency            string   `xml:"currency,omitempty"`
@@ -115,6 +116,7 @@ func (a Adjustment) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 		AccountingCode:      a.AccountingCode,
 		RevenueScheduleType: a.RevenueScheduleType,
 		ProductCode:         a.ProductCode,
+		Origin:              a.Origin,
 		UnitAmountInCents:   a.UnitAmountInCents,
 		Quantity:            a.Quantity,
 		Currency:            a.Currency,

--- a/adjustments_test.go
+++ b/adjustments_test.go
@@ -35,6 +35,17 @@ func TestAdjustments_Encoding(t *testing.T) {
 			`),
 		},
 		{
+			v: recurly.Adjustment{Origin: "external_gift_card", UnitAmountInCents: recurly.NewInt(-2000), Currency: "USD"},
+			expected: MustCompactString(`
+				<adjustment>
+					<origin>external_gift_card</origin>
+					<unit_amount_in_cents>-2000</unit_amount_in_cents>
+					<currency>USD</currency>
+				</adjustment>
+			`),
+		},
+
+		{
 			v: recurly.Adjustment{Description: "Charge for extra bandwidth", ProductCode: "bandwidth", UnitAmountInCents: recurly.NewInt(2000), Currency: "USD"},
 			expected: MustCompactString(`
 				<adjustment>


### PR DESCRIPTION
Adjustments should marshal `origin` parameters for credit calls: https://dev.recurly.com/docs/create-a-credit

```
(base) ➜  recurly git:(missing-origin) go test
PASS
ok  	github.com/blacklightcms/recurly	1.329s
```