### PR TITLE
Add Transaction Status Updated webhook

### DIFF
--- a/webhooks/payments.go
+++ b/webhooks/payments.go
@@ -9,12 +9,13 @@ import (
 // Payment notifications.
 // https://dev.recurly.com/page/webhooks#payment-notifications
 const (
-	SuccessfulPayment = "successful_payment_notification"
-	FailedPayment     = "failed_payment_notification"
-	VoidPayment       = "void_payment_notification"
-	SuccessfulRefund  = "successful_refund_notification"
-	ScheduledPayment  = "scheduled_payment_notification"
-	ProcessingPayment = "processing_payment_notification"
+	SuccessfulPayment        = "successful_payment_notification"
+	FailedPayment            = "failed_payment_notification"
+	VoidPayment              = "void_payment_notification"
+	SuccessfulRefund         = "successful_refund_notification"
+	ScheduledPayment         = "scheduled_payment_notification"
+	ProcessingPayment        = "processing_payment_notification"
+	TransactionStatusUpdated = "transaction_status_updated_notification"
 )
 
 // PaymentNotification is returned for all credit payment notifications.

--- a/webhooks/testdata/transaction_status_updated_notification.xml
+++ b/webhooks/testdata/transaction_status_updated_notification.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<transaction_status_updated_notification>
+   <account>
+      <account_code>1</account_code>
+      <username nil="true">verena</username>
+      <email>verena@example.com</email>
+      <first_name>Verena</first_name>
+      <last_name>Example</last_name>
+      <company_name nil="true">Company, Inc.</company_name>
+   </account>
+   <transaction>
+      <id>a5143c1d3a6f4a8287d0e2cc1d4c0427</id>
+      <invoice_id>ffc64d71d4b5404e93f13aac9c63b007</invoice_id>
+      <invoice_number type="integer">2059</invoice_number>
+      <subscription_id>1974a098jhlkjasdfljkha898326881c</subscription_id>
+      <action>purchase</action>
+      <date type="datetime">2010-10-05T23:00:50Z</date>
+      <amount_in_cents type="integer">1000</amount_in_cents>
+      <status>void</status>
+      <message>Test Gateway: Successful test transaction</message>
+      <reference>reference</reference>
+      <source>subscription</source>
+      <cvv_result code="" />
+      <avs_result code="" />
+      <avs_result_street />
+      <avs_result_postal />
+      <test type="boolean">true</test>
+      <voidable type="boolean">true</voidable>
+      <refundable type="boolean">true</refundable>
+   </transaction>
+</transaction_status_updated_notification>

--- a/webhooks/webhooks.go
+++ b/webhooks/webhooks.go
@@ -61,7 +61,7 @@ func nameToNotification(name string) (interface{}, error) {
 		return &CreditInvoiceNotification{Type: name}, nil
 	case NewCreditPayment, VoidedCreditPayment:
 		return &CreditPaymentNotification{Type: name}, nil
-	case SuccessfulPayment, FailedPayment, VoidPayment, SuccessfulRefund, ScheduledPayment, ProcessingPayment:
+	case SuccessfulPayment, FailedPayment, VoidPayment, SuccessfulRefund, ScheduledPayment, ProcessingPayment, TransactionStatusUpdated:
 		return &PaymentNotification{Type: name}, nil
 	case NewDunningEvent:
 		return &NewDunningEventNotification{Type: name}, nil

--- a/webhooks/webhooks_test.go
+++ b/webhooks/webhooks_test.go
@@ -814,6 +814,41 @@ func TestParse_ScheduledPaymentNotification(t *testing.T) {
 	}
 }
 
+func TestParse_TransactionStatusUpdatedNotification(t *testing.T) {
+	result := MustParseFile("testdata/transaction_status_updated_notification.xml")
+	if n, ok := result.(*webhooks.PaymentNotification); !ok {
+		t.Fatalf("unexpected type: %T, result", n)
+	} else if diff := cmp.Diff(n, &webhooks.PaymentNotification{
+		Type: webhooks.TransactionStatusUpdated,
+		Account: webhooks.Account{
+			XMLName:     xml.Name{Local: "account"},
+			Code:        "1",
+			Username:    "verena",
+			Email:       "verena@example.com",
+			FirstName:   "Verena",
+			LastName:    "Example",
+			CompanyName: "Company, Inc.",
+		},
+		Transaction: webhooks.Transaction{
+			XMLName:          xml.Name{Local: "transaction"},
+			UUID:             "a5143c1d3a6f4a8287d0e2cc1d4c0427",
+			InvoiceNumber:    2059,
+			SubscriptionUUID: "1974a098jhlkjasdfljkha898326881c",
+			Action:           "purchase",
+			AmountInCents:    1000,
+			Status:           "void",
+			Message:          "Test Gateway: Successful test transaction",
+			Reference:        "reference",
+			Source:           "subscription",
+			Test:             recurly.NewBool(true),
+			Voidable:         recurly.NewBool(true),
+			Refundable:       recurly.NewBool(true),
+		},
+	}); diff != "" {
+		t.Fatal(diff)
+	}
+}
+
 func TestParse_NewDunningEventNotification(t *testing.T) {
 	result := MustParseFile("testdata/new_dunning_event_notification.xml")
 	if n, ok := result.(*webhooks.NewDunningEventNotification); !ok {


### PR DESCRIPTION
Adding support for the Transaction Status Updated Webhook.
[Recurly Documentation](https://developers.recurly.com/pages/webhooks.html#payment-notifications)

