### PR TITLE
Updates "link" header access in `populatePageCursor` to be case-insensitive

### DIFF
--- a/recurly.go
+++ b/recurly.go
@@ -235,35 +235,32 @@ func newResponse(r *http.Response) *response {
 
 func (r *response) populatePageCursor() {
 	links := r.Response.Header.Get("Link")
+	if links != "" {
+		for _, link := range strings.Split(links, ",") {
+			segments := strings.Split(strings.TrimSpace(link), ";")
 
-	if len(links) == 0 {
-		return
-	}
+			if len(segments) < 2 { // link must at least have href and rel
+				continue
+			} else if !strings.HasPrefix(segments[0], "<") || !strings.HasSuffix(segments[0], ">") { // ensure href is properly formatted
+				continue
+			}
 
-	for _, link := range strings.Split(links, ",") {
-		segments := strings.Split(strings.TrimSpace(link), ";")
+			// try to pull out cursor parameter
+			url, err := url.Parse(segments[0][1 : len(segments[0])-1])
+			if err != nil {
+				continue
+			}
 
-		if len(segments) < 2 { // link must at least have href and rel
-			continue
-		} else if !strings.HasPrefix(segments[0], "<") || !strings.HasSuffix(segments[0], ">") { // ensure href is properly formatted
-			continue
-		}
+			cursor := url.Query().Get("cursor")
+			if cursor == "" {
+				continue
+			}
 
-		// try to pull out cursor parameter
-		url, err := url.Parse(segments[0][1 : len(segments[0])-1])
-		if err != nil {
-			continue
-		}
-
-		cursor := url.Query().Get("cursor")
-		if cursor == "" {
-			continue
-		}
-
-		for _, segment := range segments[1:] {
-			switch strings.TrimSpace(segment) {
-			case `rel="next"`:
-				r.cursor = cursor
+			for _, segment := range segments[1:] {
+				switch strings.TrimSpace(segment) {
+				case `rel="next"`:
+					r.cursor = cursor
+				}
 			}
 		}
 	}

--- a/recurly.go
+++ b/recurly.go
@@ -234,12 +234,13 @@ func newResponse(r *http.Response) *response {
 }
 
 func (r *response) populatePageCursor() {
-	links, ok := r.Response.Header["Link"]
-	if !ok || len(links) == 0 {
+	links := r.Response.Header.Get("Link")
+
+	if len(links) == 0 {
 		return
 	}
 
-	for _, link := range strings.Split(links[0], ",") {
+	for _, link := range strings.Split(links, ",") {
 		segments := strings.Split(strings.TrimSpace(link), ";")
 
 		if len(segments) < 2 { // link must at least have href and rel


### PR DESCRIPTION
Recurly's API recently updated the casing of some response headers. While this doesn't affect this client library at all right now, there is no guarantee that any response header's casing will be the same going forward.

The only header that's accessed in a case-sensitive manner is the "Link" header in the `populatePageCursor` function. Right now, this works fine, as the "Link" response header hasn't been changed, but this isn't guaranteed to stay this way in the future (see [HTTP 1.1 RFC 2616](https://tools.ietf.org/html/rfc2616#section-4.2), which states that "field-names are case insensitive" for more info on this).

I'd be happy to add an assertion for this as well if it's helpful! Please feel free to respond in the PR or reach out if you have any questions, concerns, or anything at all.